### PR TITLE
Disallow negative distances/flight hours in calculator

### DIFF
--- a/app/models/lifestyle_footprint.rb
+++ b/app/models/lifestyle_footprint.rb
@@ -13,8 +13,8 @@ class LifestyleFootprint < ApplicationRecord
   attribute :total, :greenhouse_gases
 
   validates :key, uniqueness: true, format: { with: /\A[a-f0-9]{40}\z/ }
-  validates_presence_of :housing, :food, :car, :flights, :consumption, :public, :total, :car_distance_answer,
-                        :flight_hours_answer
+  validates_presence_of :housing, :food, :car, :flights, :consumption, :public, :total
+  validates :car_distance_answer, :flight_hours_answer, numericality: { greater_than_or_equal_to: 0 }
   validate :answers_exist_in_calculator
 
   before_validation :generate_key

--- a/app/views/lifestyle_footprints/new.html.erb
+++ b/app/views/lifestyle_footprints/new.html.erb
@@ -162,7 +162,7 @@
             <h2 class="font-semibold text-xl my-4"><%=t 'views.lifestyle_footprints.questions.car_distance' %></h2>
             <div class="flex flex-col sm:flex-row">
               <label class="input inline-block mb-3 sm:mb-0 sm:mr-3 flex">
-                <%= number_field_tag :car_distance_week_answer, '', size: 7, class: 'flex-1' %>
+                <%= number_field_tag :car_distance_week_answer, '', min: 0, size: 7, class: 'flex-1' %>
                 <span class="text-gray-700 ml-3"><%= @calculator.car_distance_unit %></span>
               </label>
               <%= f.button t('views.lifestyle_footprints.next'), type: 'button', class: 'button flex-1', 'data-action': 'click->lifestyle-calculator#nextQuestion' %>
@@ -173,7 +173,7 @@
         <div class="question py-8 hidden" data-target="lifestyle-calculator.question" data-category="flights">
           <h2 class="font-semibold text-xl my-4"><%=t 'views.lifestyle_footprints.questions.flight_hours' %></h2>
           <div class="flex flex-col sm:flex-row">
-            <%= f.number_field :flight_hours_answer, class: 'input mb-3 sm:mb-0 sm:mr-3', size: 7 %>
+            <%= f.number_field :flight_hours_answer, min: 0, size: 7, class: 'input mb-3 sm:mb-0 sm:mr-3' %>
             <%= f.submit t('views.lifestyle_footprints.next'), class: 'button flex-1' %>
           </div>
         </div>

--- a/spec/models/lifestyle_footprint_spec.rb
+++ b/spec/models/lifestyle_footprint_spec.rb
@@ -16,6 +16,22 @@ RSpec.describe LifestyleFootprint do
     end
   end
 
+  describe '#car_distance_answer' do
+    it 'validates to not be negative' do
+      footprint = described_class.new(car_distance_answer: -1)
+      footprint.valid?
+      expect(footprint.errors).to include(:car_distance_answer)
+    end
+  end
+
+  describe '#flight_hours_answer' do
+    it 'validates to not be negative' do
+      footprint = described_class.new(flight_hours_answer: -1)
+      footprint.valid?
+      expect(footprint.errors).to include(:flight_hours_answer)
+    end
+  end
+
   [
     :region, :home, :heating, :house_age, :green_electricity, :food, :car_type
   ].each do |category|


### PR DESCRIPTION
Before this change, you could give yourself a "discount" on your
footprint by entering negative numbers :).

Setting min="0" on <input type="number"> seems to be enough in both
Safari/WebKit and Firefox to also stop the stepper from going below
zero. Entering a negative value will still result in not being able to
click Next to finish the calculator, but hopefully this case is
extremely rare.