### PR TITLE
Persist country for LifestyleFootprint for future use

### DIFF
--- a/app/controllers/lifestyle_footprints_controller.rb
+++ b/app/controllers/lifestyle_footprints_controller.rb
@@ -23,7 +23,7 @@ class LifestyleFootprintsController < ApplicationController
 
   def footprint_params
     params.require(:lifestyle_footprint).permit(
-      :lifestyle_calculator_id, :region_answer, :home_answer,
+      :lifestyle_calculator_id, :country, :region_answer, :home_answer,
       :heating_answer, :house_age_answer, :green_electricity_answer,
       :food_answer, :car_type_answer, :flight_hours_answer
     ).tap do |p|

--- a/app/models/lifestyle_footprint.rb
+++ b/app/models/lifestyle_footprint.rb
@@ -4,6 +4,7 @@ class LifestyleFootprint < ApplicationRecord
   belongs_to :lifestyle_calculator
   belongs_to :user, optional: true
 
+  attribute :country, :country
   attribute :housing, :greenhouse_gases
   attribute :food, :greenhouse_gases
   attribute :car, :greenhouse_gases
@@ -13,7 +14,7 @@ class LifestyleFootprint < ApplicationRecord
   attribute :total, :greenhouse_gases
 
   validates :key, uniqueness: true, format: { with: /\A[a-f0-9]{40}\z/ }
-  validates_presence_of :housing, :food, :car, :flights, :consumption, :public, :total
+  validates_presence_of :country, :housing, :food, :car, :flights, :consumption, :public, :total
   validates :car_distance_answer, :flight_hours_answer, numericality: { greater_than_or_equal_to: 0 }
   validate :answers_exist_in_calculator
 

--- a/app/views/lifestyle_footprints/new.html.erb
+++ b/app/views/lifestyle_footprints/new.html.erb
@@ -71,6 +71,7 @@
 
       <%= form_with model: @footprint do |f| %>
         <%= f.hidden_field :lifestyle_calculator_id %>
+        <%= f.hidden_field :country, value: params[:country] %>
 
         <% if @calculator.region_options.present? %>
           <div class="question py-8 hidden" data-target="lifestyle-calculator.question" data-category="home">

--- a/spec/factories/lifestyle_footprint.rb
+++ b/spec/factories/lifestyle_footprint.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :lifestyle_footprint do
     key { 'a9993e364706816aba3e25717850c26c9cd0d89d' }
     lifestyle_calculator
+    country { lifestyle_calculator.countries.first }
     region_answer { 'first' }
     home_answer { 'apartment' }
     heating_answer { 'district' }

--- a/spec/models/lifestyle_footprint_spec.rb
+++ b/spec/models/lifestyle_footprint_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe LifestyleFootprint do
   [
-    :lifestyle_calculator, :housing, :food, :car, :flights, :consumption,
-    :public, :total, :car_distance_answer, :flight_hours_answer
+    :lifestyle_calculator, :country, :housing, :food, :car, :flights,
+    :consumption, :public, :total, :car_distance_answer,
+    :flight_hours_answer
   ].each do |attribute|
     describe "##{attribute}" do
       it 'validates to be present' do


### PR DESCRIPTION
We'd like to be able to prompt users when updated calculators for their
country are published.

## Todo

- [x] Split into two PR's with the migration separate.