### PR TITLE
Add simple experiments infrastructure with YML config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def new_calculator_active?
-    return @new_calculator_active unless @new_calculator_active.nil?
-
-    active =
-      if cookies[:new_calculator].present?
-        cookies[:new_calculator] == '1'
-      else
-        rand(0..100) <= 50
-      end
-
-    active = params[:new_calculator] == '1' if params[:new_calculator].present?
-
-    cookies[:new_calculator] = { value: active ? '1' : '0', expires: 30.days.from_now }
-
-    @new_calculator_active = active
+  def experiment_active?(experiment)
+    @active_experiments.include?(experiment)
   end
 
   def price_string(amount, currency, options = {})

--- a/app/models/experiments_assignment.rb
+++ b/app/models/experiments_assignment.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class ExperimentsAssignment
+  CURRENT_EXPERIMENTS = YAML.safe_load(File.read('config/experiments.yml')).deep_symbolize_keys
+
+  attr_reader :active_experiments
+
+  def initialize(cookie_string = nil)
+    @active_experiments = []
+
+    cookie_experiments = parse_cookie_string(cookie_string)
+
+    CURRENT_EXPERIMENTS.each do |experiment, options|
+      @active_experiments << experiment if experiment_active?(experiment, options[:frequency], cookie_experiments)
+    end
+  end
+
+  def enable(experiments)
+    experiments.each do |experiment|
+      unless @active_experiments.include?(experiment) || !CURRENT_EXPERIMENTS.key?(experiment)
+        @active_experiments << experiment
+      end
+    end
+  end
+
+  def disable(experiments)
+    experiments.each { |e| @active_experiments.delete(e) }
+  end
+
+  def cookie_string
+    CURRENT_EXPERIMENTS.map do |experiment, _|
+      "#{experiment}=#{@active_experiments.include?(experiment) ? '1' : '0'}"
+    end.sort.join(',')
+  end
+
+  private
+
+  def experiment_active?(experiment, frequency, cookie_experiments)
+    if cookie_experiments[experiment].present?
+      cookie_experiments[experiment] == '1'
+    else
+      rand <= frequency
+    end
+  end
+
+  def parse_cookie_string(string)
+    return {} if string.nil?
+
+    string.split(',').map { |e| e.split('=') }.to_h.symbolize_keys
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
       ga('create', 'UA-97611261-1', 'auto');
       <% unless ENV['GOOGLE_ANALYTICS_SENDING'] == 'enabled' %>ga('set', 'sendHitTask', null);<% end %>
       ga('send', 'pageview', {
-        dimension1: <% if new_calculator_active? %>'new_calculator'<% else %>''<% end %>
+        dimension1: '<%= @active_experiments.any? ? @active_experiments.sort.join(',') : 'none' %>'
       });
     </script>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -10,7 +10,7 @@
   <%= render "shared/header_old" %>
   <div class="container">
 
-    <% if new_calculator_active? %>
+    <% if experiment_active?(:new_calculator) %>
       <div style="display: flex; align-items: center; min-height: 70vh; padding-bottom: 50px">
         <div id="choose-plan" style="width: 100%;">
           <h1 class="cover-heading top" style="margin-top: 30px">
@@ -263,7 +263,7 @@
 
 <%= render "shared/footer_old" %>
 
-<% unless new_calculator_active? %>
+<% unless experiment_active?(:new_calculator) %>
   <% content_for :javascript_tags do %>
     <script>
       $(document).ready(function() {

--- a/config/experiments.yml
+++ b/config/experiments.yml
@@ -1,0 +1,2 @@
+new_calculator:
+  frequency: 0.5

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.feature 'Registrations', type: :feature, js: true do
   scenario 'Register and update card' do
     # Homepage
-    visit '/?new_calculator=1'
+    visit '/?enable_experiments=new_calculator'
 
     select('Sweden', from: 'country')
     click_button 'Get started'
@@ -59,7 +59,7 @@ RSpec.feature 'Registrations', type: :feature, js: true do
   context 'when using 3D Secure card' do
     scenario 'Register and update card' do
       # Homepage
-      visit '/?new_calculator=1'
+      visit '/?enable_experiments=new_calculator'
 
       select('Sweden', from: 'country')
       click_button 'Get started'
@@ -122,7 +122,7 @@ RSpec.feature 'Registrations', type: :feature, js: true do
 
   scenario 'Register and update card with old calculator' do
     # Homepage
-    visit '/?new_calculator=0'
+    visit '/?disable_experiments=new_calculator'
 
     click_link 'Offset my impact'
 

--- a/spec/models/experiments_assignment_spec.rb
+++ b/spec/models/experiments_assignment_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExperimentsAssignment do
+  let(:current_experiments) {
+    {
+      experiment1: { frequency: 1 },
+      experiment2: { frequency: 0 },
+      experiment3: { frequency: 0 },
+      experiment4: { frequency: 0 }
+    }
+  }
+
+  before do
+    stub_const('ExperimentsAssignment::CURRENT_EXPERIMENTS', current_experiments)
+  end
+
+  describe '#initialize' do
+    it 'randomizes active experiments' do
+      assignment = described_class.new
+
+      expect(assignment.active_experiments).to eq([:experiment1])
+    end
+
+    it 'adheres to previous assignment provided by cookie string' do
+      assignment = described_class.new('experiment1=0,experiment2=1')
+
+      expect(assignment.active_experiments).to eq([:experiment2])
+    end
+  end
+
+  describe '#cookie_string' do
+    it 'generates cookie string with all current experiments' do
+      assignmet = described_class.new
+
+      expect(assignmet.cookie_string).to eq('experiment1=1,experiment2=0,experiment3=0,experiment4=0')
+    end
+
+    it 'sorts keys alphabetically' do
+      stub_const(
+        'ExperimentsAssignment::CURRENT_EXPERIMENTS',
+        { b: { frequency: 1 }, a: { frequency: 1 } }
+      )
+
+      assignment = described_class.new
+
+      expect(assignment.cookie_string).to eq('a=1,b=1')
+    end
+  end
+
+  describe '#enable' do
+    it 'adds provided experiments to list of active ones' do
+      assignment = described_class.new
+
+      assignment.enable([:experiment3])
+
+      expect(assignment.active_experiments).to include(:experiment3)
+    end
+
+    it 'does not add non-existing experiments' do
+      assignment = described_class.new
+
+      assignment.enable([:not_an_expriment])
+
+      expect(assignment.active_experiments).not_to include(:not_an_expriment)
+    end
+  end
+
+  describe '#disable' do
+    it 'removes provided experiments from active ones' do
+      assignment = described_class.new('experiment1=1')
+
+      assignment.disable([:experiment1])
+
+      expect(assignment.active_experiments).not_to include(:experiment1)
+    end
+  end
+end


### PR DESCRIPTION
To run an experiment, just add it to `config/experiments.yml` with the desired frequency (for new sessions, resets after 30 days). Then just call `experiment_active?` with the symbolized name of the experiment to check if it is currently assigned.

We can link to experiments by using the `enable_experiments` and `disable_experiments` query params, like this: `https://www.goclimateneutral.org/?enable_experiments=new_calculator` and to disable: `https://www.goclimateneutral.org/?disable_experiments=new_calculator`. These get saved to the cookie like others so subsequent page views/visits keep that preference.

Experiments get reported to Google Analytics as a (sorted) comma separated string to the custom dimension called 'Experiments' (`dimension1`). If no experiment is active, it's reported as `none` so we can easily list the baseline separately if need be.