### PR TITLE
Split only one chunk for node_modules used by main JS entrypoint

### DIFF
--- a/config/webpack/common.js
+++ b/config/webpack/common.js
@@ -95,7 +95,14 @@ module.exports = {
   },
   optimization: {
     splitChunks: {
-      chunks: 'all',
+      cacheGroups: {
+        modules: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'modules',
+          // Currently undocument feature:  https://github.com/webpack/webpack/pull/6791
+          chunks: (chunk) => chunk.name.match(/^main|main_old$/)
+        }
+      },
       name: false
     },
     moduleIds: 'hashed'


### PR DESCRIPTION
We've grown in entrypoints and module usage, leading to many chunks
being generated and most of them necessary to load initially for all
primary site visitors. This generates uneccessary requests and makes
debugging confusing when our sources are spread among many entrypoints.

This change changes chunks to only apply to the main entrypoints, and to
only ever create one chunk for modules. This lets the modules be cached
for a longer time, while keeping the number of requests down. API/admin
entrypoints are now fat, including all their modules, but those are
fewer both in dependencies and number of visitors.