### PR TITLE
New design for login pages

### DIFF
--- a/app/assets/main/components/button.scss
+++ b/app/assets/main/components/button.scss
@@ -3,6 +3,7 @@
     inline-block
     py-2 px-4
     border rounded border-current
+    bg-transparent
     whitespace-no-wrap
     text-primary
     transition duration-200

--- a/app/assets/main/components/callout.scss
+++ b/app/assets/main/components/callout.scss
@@ -1,0 +1,7 @@
+.callout {
+  @apply bg-white rounded-lg shadow-lg p-4;
+
+  @screen t {
+    @apply p-8;
+  }
+}

--- a/app/assets/main/components/dropdown.scss
+++ b/app/assets/main/components/dropdown.scss
@@ -10,7 +10,7 @@
         py-1
         border border-0 rounded
         text-primary text-left bg-white
-        shadow-md;
+        shadow;
 
       .dropdown-toggler:checked ~ & {
         @apply block;

--- a/app/assets/main/components/dropdown.scss
+++ b/app/assets/main/components/dropdown.scss
@@ -37,7 +37,7 @@
       }
 
       & > li > a:active {
-        @apply scale-100; /* Override buttons used in smaller breakpoints */
+        @apply translate-x-0; /* Override buttons used in smaller breakpoints */
       }
     }
   }

--- a/app/assets/main/components/input.scss
+++ b/app/assets/main/components/input.scss
@@ -12,9 +12,7 @@
     cursor-text; /* For when we're styling a container as the input */
 
   &:focus-within, &:focus, &.StripeElement--focus {
-    @apply
-      border-transparent
-      shadow-outline;
+    @apply shadow-outline;
   }
 
   /* Disable default focus styling by browsers */

--- a/app/assets/main/components/lists.scss
+++ b/app/assets/main/components/lists.scss
@@ -1,0 +1,5 @@
+.list-bullet li::before {
+  content: '\2022';
+  width: 1em;
+  display: inline-block;
+}

--- a/app/assets/main/index.scss
+++ b/app/assets/main/index.scss
@@ -3,11 +3,13 @@
 @import 'tailwindcss/components';
 
 @import 'components/button.scss';
+@import 'components/callout.scss';
 @import 'components/collapse.scss';
 @import 'components/dropdown.scss';
 @import 'components/headings.scss';
 @import 'components/input.scss';
 @import 'components/link.scss';
+@import 'components/lists.scss';
 @import 'components/section_gutter.scss';
 @import 'components/section_padding.scss';
 @import 'components/select.scss';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,8 @@ class ApplicationController < ActionController::Base
   #
   # TODO: Remove when we're done testing & migrating to new design
   def render_to_body(options)
-    if params.key?('new_design')
+    if cookies[:new_design].present? || params.key?('new_design')
+      cookies[:new_design] = '1'
       return(
         begin
           super(options.merge(template: "#{options[:template]}_new"))

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -14,7 +14,7 @@
     <p class="lead"><%=t 'change_your_password_by_entering_your_new_password_below' %></p>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "form-horizontal" }) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= render "devise/shared/error_messages_old", resource: resource %>
 
       <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,7 +14,7 @@
     <p class="lead"><%= description(t('enter_your_email_below_and_we_will_send_you')) %></p>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "form-horizontal" }) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= render "devise/shared/error_messages_old", resource: resource %>
 
       <div class="form-group">
         <div class="col-sm-1"></div>

--- a/app/views/devise/passwords/new_new.html.erb
+++ b/app/views/devise/passwords/new_new.html.erb
@@ -1,0 +1,23 @@
+<%= render "shared/header" %>
+
+<div class="section-padding">
+
+  <div class="callout max-w-lg mx-auto space-y-4">
+    <h1 class="heading-lg"><%= title(t('forgot_your_password')) %></h1>
+    <p><%= description(t('enter_your_email_below_and_we_will_send_you')) %></p>
+
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
+      <label class="block">
+        <strong class="block"><%=t 'email' %></strong>
+        <%= f.email_field :email, autofocus: true, required: true, class: "input w-full" %>
+      </label>
+
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <button type="submit" class="button button-primary"><%=t 'send_me_an_email_with_instructions' %></button>
+    <% end %>
+
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -14,7 +14,7 @@
     <%= render "shared/user_menu" %>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, :class => "form-horizontal" }) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= render "devise/shared/error_messages_old", resource: resource %>
 
       <div class="form-group">
         <div class="col-sm-1"></div>

--- a/app/views/devise/sessions/new_new.html.erb
+++ b/app/views/devise/sessions/new_new.html.erb
@@ -1,0 +1,41 @@
+<%= render "shared/header" %>
+
+<div class="section-padding">
+
+  <div class="callout max-w-lg mx-auto space-y-4">
+    <h1 class="heading-lg"><%= title(t('log_in')) %></h1>
+    <p><%= description(t('log_in_to_see_how_we_are_doing')) %></p>
+
+    <%= form_for resource, as: resource_name, url: session_path(resource_name), html: { class: 'space-y-4' } do |f| %>
+
+      <label class="block">
+        <strong class="block"><%=t 'email' %></strong>
+        <%= f.email_field :email, autofocus: true, required: true, class: "input w-full" %>
+      </label>
+
+      <label class="block">
+        <strong class="block"><%=t 'password' %></strong>
+        <%= f.password_field :password, required: true, class: "input w-full" %>
+      </label>
+
+      <% if devise_mapping.rememberable? -%>
+        <label class="block">
+          <%= f.check_box :remember_me, checked: true %>
+          <%= t 'activerecord.attributes.user.remember_me' %>
+        </label>
+      <% end -%>
+
+      <div class="flex items-center space-x-4">
+        <button type="submit" class="button button-primary">
+          <%=t 'log_in' %>
+        </button>
+
+        <span>
+          <%= link_to t('forgot_your_password'), new_user_password_path, class: 'link' %>
+        </span>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,18 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+  <div class="flex items-center space-x-4">
+    <span class="fa fa-exclamation-triangle text-orange-accent fa-lg"></span>
+    <div class="flex-grow text-orange-dark">
+      <p class="text-large font-bold">
+        <%= I18n.t("errors.messages.not_saved",
+                   count: resource.errors.count,
+                   resource: resource.class.model_name.human.downcase)
+         %>
+      </p>
+      <ul class="list-bullet">
+        <% resource.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 <% end %>

--- a/app/views/devise/shared/_error_messages_old.html.erb
+++ b/app/views/devise/shared/_error_messages_old.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -86,7 +86,7 @@
 <% end %>
 
 <% if notice || alert %>
-  <div class="p-4 t:px-8 text-center bg-primary text-white" role="alert">
+  <div id="alert" class="p-4 t:px-8 text-center bg-primary text-white" role="alert">
     <% if notice %>
       <p><span class="fa fa-exclamation-circle"></span> <%= notice %></p>
     <% elsif alert %>
@@ -97,7 +97,7 @@
     <script>
       $(document).ready(function() {
         setTimeout(function() {
-          $(".alert").slideUp(1000);
+          $("#alert").slideUp(1000);
         }, 5000);
       });
     </script>

--- a/app/views/shared/_header_old_tailwind.html.erb
+++ b/app/views/shared/_header_old_tailwind.html.erb
@@ -27,7 +27,7 @@
 <% end %>
 
 <% if notice || alert %>
-  <div class="p-4 text-center alert bg-alert-300 text-alert-700 border rounded-sm border-alert-600" role="alert">
+  <div class="p-4 text-center alert bg-alert-300 text-alert-700 border rounded border-alert-600" role="alert">
     <% if notice %>
       <p class="notice"><%= notice %></p>
     <% elsif alert %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,7 +209,7 @@ en:
   why_goclimateneutral_head: WHY GOCLIMATENEUTRAL?
   forgot_your_password: Forgot your password?
   enter_your_email_below_and_we_will_send_you: Enter your email below and we will send you an email with instructions.
-  send_me_an_email_with_instructions: Send me reset password instructions!
+  send_me_an_email_with_instructions: Reset password
   change_your_password: Change your password
   change_your_password_by_entering_your_new_password_below: Change your password by entering your new password below.
   change_password: Change password
@@ -409,7 +409,6 @@ en:
                 blank: Wops, the password looks like it´s empty!
               email:
                 taken: The email address already exists, try another one!
-                blank: The email-field looks empty!
                 invalid: The email looks incorrect, try again!
               privacy_policy: 
                 accepted: You need to accept the pricacy policy

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -209,7 +209,7 @@ sv:
   why_goclimateneutral_head: VARFÖR GOCLIMATENEUTRAL?
   forgot_your_password: Glömt ditt lösenord?
   enter_your_email_below_and_we_will_send_you: Skriv in din e-post nedan så mailar vi dig instruktioner.
-  send_me_an_email_with_instructions: Skicka ett mail till mig!
+  send_me_an_email_with_instructions: Återställ lösenord
   change_your_password: Ändra ditt lösenord
   change_your_password_by_entering_your_new_password_below: Ändra ditt lösenord genom att skriva in ditt nya lösenord här.
   change_password: Ändra lösenord
@@ -418,6 +418,9 @@ sv:
         question: Hur hanteras mina kortuppgifter?
         answer: Vi använder oss av Stripe (<a href="https://stripe.com/se">stripe.com</a>) som betalningsleverantör, som är en av de största betalningsleverantörerna på nätet. Kortuppgifterna och betalningarna hanteras helt och hållet av dem - helt krypterat förstås. Kortuppgifterna hamnar aldrig på våra eller någon annans servrar, utan hanteras endast utav Stripe.
   activerecord:
+    attributes:
+      user:
+        email: E-post
     errors:
       models:
         user:
@@ -427,7 +430,7 @@ sv:
                 blank: Oj, lösenordet ser tomt ut!
               email:
                 taken: Användaren finns redan registrerad hos oss, prova med en annan e-postadress!
-                blank: E-postfältet ser tomt ut!
+                blank: måste anges
                 invalid: E-postadressen ser konstig ut, prova igen!
               privacy_policy: 
                 accepted: Du behöver acceptera integritetspolocyn för att gå vidare

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -132,9 +132,9 @@ module.exports = {
         '-10': '-10'
       },
       transitionProperty: {
-        default: 'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, border-width height width max-height max-width',
+        default: 'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, border-width, height, width, max-height, max-width',
         border: 'border-width',
-        size: 'height width max-height max-width'
+        size: 'height, width, max-height, max-width'
       }
     }
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -98,6 +98,18 @@ module.exports = {
       'big-icon': '12rem' // temporary
     }),
     fontFamily: false,
+    borderRadius: {
+      none: '0',
+      default: '0.25rem',
+      lg: '0.5rem',
+      full: '9999px'
+    },
+    boxShadow: (theme) => ({
+      default: '0 3px 10px -3px rgba(28, 70, 55, 0.2), 0 1px 3px 0px rgba(28, 70, 55, 0.1)',
+      lg: '0 15px 30px -5px rgba(28, 70, 55, 0.1), 0 10px 10px -5px rgba(28, 70, 55, 0.05)',
+      outline: `0 0 0 1px ${theme('colors.primary')}`,
+      none: 'none'
+    }),
     extend: {
       inset: { // top/right/bottom/left
         100: '100%',
@@ -119,9 +131,6 @@ module.exports = {
       zIndex: {
         '-10': '-10'
       },
-      boxShadow: (theme) => ({
-        outline: `0 0 0 3px ${theme('colors.primary')}`
-      }),
       transitionProperty: {
         default: 'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, border-width height width max-height max-width',
         border: 'border-width',


### PR DESCRIPTION
Looks like this:

<img width="1111" alt="desktop" src="https://user-images.githubusercontent.com/90949/81820443-eb7c9280-9530-11ea-8082-89da4083139c.png">

<img width="375" alt="mobile" src="https://user-images.githubusercontent.com/90949/81819996-4e215e80-9530-11ea-9ee5-d16d44f3555d.png">

---

Also sets new defaults for rounded corners and drop shadows. Two of each is all you get for now, one default for smaller things (like buttons & dropdown menus) and one large for... well larger things (like callout boxes). I don't see anything else right now so let's add more when we know what they're for?