### PR TITLE
Make project optional for invoices

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Invoice < ApplicationRecord
-  belongs_to :project
+  belongs_to :project, optional: true
   validates :certificate_reciever_email, email: true
 end


### PR DESCRIPTION
It's important that we register all offset-invoices in our system to keep track of CO2e left total and left in every project. So far the check that everything is registered has been done manually now and then. By making project optional we can add all invoices to Invoice, even ones without a project, which makes it easy to track which invoices are not registered yet. This will also have the side effect that we can keep track of business income in our app.