### PR TITLE
Add really simple sitemap

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# frozen_string_literal: true
 
 class SitemapController < ApplicationController
   before_action :set_base_url
@@ -11,16 +10,14 @@ class SitemapController < ApplicationController
   end
 
   def content
-    @locations = []
-    pages = %w[
-      about contact business faq press 100_percent_transparency travel_calculator
-      our_projects flights gift_cards
+    @all_urls = []
+    url_helpers = [
+      :about, :contact, :business, :faq, :press, :transparency, :travel_calculator,
+      :projects, :flight_offsets, :gift_cards
     ]
 
     Region.all.each do |region|
-      pages.each do |page|
-        @locations << (region.slug.nil? ? page : "#{region.slug}/#{page}")
-      end
+      @all_urls += url_helpers.map { |helper| [polymorphic_url(helper, region: region), helper] }
     end
 
     respond_to do |format|

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# frozen_string_literal: true
+
+class SitemapController < ApplicationController
+  before_action :set_base_url
+
+  def index
+    respond_to do |format|
+      format.xml
+    end
+  end
+
+  def content
+    @locations = []
+    pages = %w[
+      about contact business faq press 100_percent_transparency travel_calculator
+      our_projects flights gift_cards
+    ]
+
+    Region.all.each do |region|
+      pages.each do |page|
+        @locations << (region.slug.nil? ? page : "#{region.slug}/#{page}")
+      end
+    end
+
+    respond_to do |format|
+      format.xml
+    end
+  end
+
+  def set_base_url
+    @base_url = "#{request.protocol}#{request.host_with_port}/"
+  end
+end

--- a/app/views/sitemap/_common.xml.builder
+++ b/app/views/sitemap/_common.xml.builder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+@locations.each do |location|
+  xml.url do
+    xml.loc(@base_url + location)
+    xml.changefreq('daily')
+  end
+end

--- a/app/views/sitemap/_common.xml.builder
+++ b/app/views/sitemap/_common.xml.builder
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-@locations.each do |location|
-  xml.url do
-    xml.loc(@base_url + location)
-    xml.changefreq('daily')
-  end
-end

--- a/app/views/sitemap/content.xml.builder
+++ b/app/views/sitemap/content.xml.builder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+xml.instruct!(:xml, version: '1.0')
+xml.tag!('urlset', 'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9') do
+  xml << (render partial: 'sitemap/common', locations: @locations, base_url: @base_url)
+end

--- a/app/views/sitemap/content.xml.builder
+++ b/app/views/sitemap/content.xml.builder
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 xml.instruct!(:xml, version: '1.0')
-xml.tag!('urlset', 'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9') do
-  xml << (render partial: 'sitemap/common', locations: @locations, base_url: @base_url)
+xml.tag!(
+  'urlset',
+  'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9',
+  'xmlns:xhtml': 'http://www.w3.org/1999/xhtml'
+) do
+  @all_urls.each do |url, helper|
+    xml.url do
+      xml.loc(url)
+      xml.changefreq('daily')
+      Region.all.each do |region|
+        xml.tag!(
+          'xhtml:link',
+          rel: 'alternate',
+          hreflang: region.logical_locale,
+          href: polymorphic_url(helper, region: region)
+        )
+      end
+    end
+  end
 end

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 xml.instruct!(:xml, version: '1.0')
-xml.tag!('sitemapindex', 'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9') do
+xml.tag!(
+  'sitemapindex',
+  'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9',
+  'xmlns:xhtml': 'http://www.w3.org/1999/xhtml'
+) do
   xml.sitemap do
     xml.loc(@base_url + 'sitemap_content.xml')
   end
   xml.sitemap do
     xml.loc(@base_url + 'blog/sitemap_index.xml')
-  end
-  xml.sitemap do
-    xml.loc('https://jobs.goclimateneutral.org/sitemap.xml')
   end
 end

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+xml.instruct!(:xml, version: '1.0')
+xml.tag!('sitemapindex', 'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9') do
+  xml.sitemap do
+    xml.loc(@base_url + 'sitemap_content.xml')
+  end
+  xml.sitemap do
+    xml.loc(@base_url + 'blog/sitemap_index.xml')
+  end
+  xml.sitemap do
+    xml.loc('https://jobs.goclimateneutral.org/sitemap.xml')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,4 +180,8 @@ Rails.application.routes.draw do
 
   # Vanity URL redirects
   get '/blog', to: redirect('https://www.goclimateneutral.org/blog/'), as: nil
+
+  # Sitemap xml
+  get '/sitemap.xml' => 'sitemap#index', :format => 'xml', :as => :sitemap
+  get '/sitemap_content.xml' => 'sitemap#content', :format => 'xml', :as => :sitemap_content
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://www.goclimate.com/sitemap.xml


### PR DESCRIPTION
I evaluated the SitemapGenerator gem that generats a sitemap and saves it to s3 (since heroku can't save files more then temporary). But since our generation of urls are not very load heavy yet and the SitemapGenerator version ended up a bit more complex than I felt comfortable with (s3 account, heroku scheduler, more gems, more magic etc) I ended up with this version. Simple, but maybe a bit wordier with less magic stuff helping out with the xml generation.