### PR TITLE
Fix illustration offset bug

### DIFF
--- a/app/views/home/show_new.html.erb
+++ b/app/views/home/show_new.html.erb
@@ -52,7 +52,7 @@
           style: 'margin-right: -120px', alt: '' %>
       </div>
     </div>
-    <div class="absolute -mx-32 t:mx-0 h-full t:w-full">
+    <div class="absolute h-full w-full">
       <%= image_tag webpack_asset_path('images/illustrations/hero/horizon.svg'), class: 'w-full h-full', alt: '' %>
     </div>
     <div class="absolute h-full w-full">

--- a/app/views/shared/_bottom_landscape.html.erb
+++ b/app/views/shared/_bottom_landscape.html.erb
@@ -1,7 +1,7 @@
 <div class="relative overflow-x-hidden w-full h-48 t:h-64">
   <%= image_tag webpack_asset_path('images/illustrations/prefooter/behind_left.png'), class: 'absolute right-1/2 d:right-auto d:left-0 h-full max-w-none', alt: '' %>
   <%= image_tag webpack_asset_path('images/illustrations/prefooter/behind_right.png'), class: 'absolute left-1/2 d:left-auto d:right-0 h-full max-w-none', alt: '' %>
-  <div class="absolute -mx-32 t:mx-0 h-full t:w-full">
+  <div class="absolute h-full w-full">
     <%= image_tag webpack_asset_path('images/illustrations/prefooter/ground.svg'), class: 'w-full h-full', alt: '' %>
   </div>
   <%= image_tag webpack_asset_path('images/illustrations/prefooter/left-1x.png'),


### PR DESCRIPTION
The grass in the hero and prefooter illustrations were imporperly offset, however issue was only present in Chrome browsers.

![Screenshot 2020-07-01 at 11 43 28](https://user-images.githubusercontent.com/8473077/86230180-06629f00-bb91-11ea-8e27-4e64dff20acc.png)
![Screenshot 2020-07-01 at 11 43 40](https://user-images.githubusercontent.com/8473077/86230186-0793cc00-bb91-11ea-9b9a-6ae356f0f18c.png)
![Screenshot 2020-07-01 at 11 43 55](https://user-images.githubusercontent.com/8473077/86230189-08c4f900-bb91-11ea-919e-d1795b15b056.png)
![Screenshot 2020-07-01 at 11 44 07](https://user-images.githubusercontent.com/8473077/86230193-095d8f80-bb91-11ea-8abe-3302c9cdb834.png)



