### PR TITLE
Replace Font Awesome icons with Material icons

### DIFF
--- a/app/assets/main/components/lists.scss
+++ b/app/assets/main/components/lists.scss
@@ -13,8 +13,8 @@
 
 .list-check {
   li::before {
-    font-family: FontAwesome;
-    content: "\f00c";
+    font-family: "Material Icons Round";
+    content: "check";
     font-size: 1.5rem;
 
     @apply

--- a/app/assets/main/components/select.scss
+++ b/app/assets/main/components/select.scss
@@ -18,8 +18,8 @@
   @apply relative inline-block;
 
   &::after {
-    font-family: FontAwesome;
-    content: "\f107";
+    font-family: "Material Icons Round";
+    content: "expand_more";
 
     @apply 
       absolute right-0 top-1/2

--- a/app/views/about/faq/show.html.erb
+++ b/app/views/about/faq/show.html.erb
@@ -35,7 +35,7 @@
               <h3 class="heading">
                   <%= question[:question] %>
               </h3>
-              <span class="fa fa-chevron-down transform toggler-checked:rotate-180 transition-transform duration-200"></span>
+              <span class="material-icons-round transform toggler-checked:rotate-180 transition-transform duration-200">expand_more</span>
             </label>
 
             <div class="hidden toggler-checked:block">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -127,7 +127,10 @@
                   <div class="">
                     <div id="card" class="input mb-1" data-target="stripe-card-element.container"></div>
                     <div class="text-orange-shade-1" data-target="stripe-card-element.errors"></div>
-                    <i class="fa fa-lock" aria-hidden="true"></i> <span class="ml-1">Secured by Stripe</span>
+                    <div class="flex items-center">
+                      <span class="material-icons-round" aria-hidden="true">lock</span>
+                      <span class="ml-1">Secured by Stripe</span>
+                    </div>
                     <%= f.hidden_field :payment_method_id, 'data-target': 'stripe-card-element.paymentMethodField' %>
                   </div>
                 </div>
@@ -148,8 +151,8 @@
               <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
             </p>
 
-            <button class="button button-cta w-full" data-target="registration-form.submitButton" data-action="registration-form#submit">
-              <i class="fa fa-spinner fa-spin hidden" data-target="registration-form.loadingIndicator"></i>
+            <button class="button button-cta w-full flex items-center justify-center" data-target="registration-form.submitButton" data-action="registration-form#submit">
+              <span class="material-icons-round mr-1 hidden" data-target="registration-form.loadingIndicator">hourglass_bottom</span>
               <%= t 'views.registrations.start_subscription' %>
             </button>
             <p class="text-orange-shade-1 ml-4" data-target="registration-form.errorMessage"></p>
@@ -219,7 +222,7 @@
           <input id="question-<%= q %>" type="checkbox">
           <label for="question-<%= q %>" class="flex justify-between cursor-pointer">
             <div class="font-semibold"><%= t "faq_questions.#{q}.question" %></div>
-            <div class="pl-3"><i class="fa fa-chevron-circle-down collapse-chevron" aria-hidden="true"></i></div>
+            <div class="pl-3"><span class="material-icons-round collapse-chevron" aria-hidden="true">expand_more</span></div>
           </label>
           <div class="pt-4 collapse-content"><%= raw(t("faq_questions.#{q}.answer")) %></div>
         </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,8 +1,10 @@
 <% if resource.errors.any? %>
   <div class="flex items-center space-x-4">
-    <span class="fa fa-exclamation-triangle text-orange-accent fa-lg"></span>
+    <span class="text-lg">
+      <i class="material-icons-round mr-1 text-orange-accent" aria-hidden="true">warning</i>
+    </span>
     <div class="flex-grow text-orange-dark">
-      <p class="text-large font-bold">
+      <p class="text-lg font-bold">
         <%= I18n.t("errors.messages.not_saved",
                    count: resource.errors.count,
                    resource: resource.class.model_name.human.downcase)

--- a/app/views/flight_footprints/new.html.erb
+++ b/app/views/flight_footprints/new.html.erb
@@ -51,8 +51,8 @@
               <div class="hidden" data-controller="airport-field" data-target="template-element.template airport-field.container" data-search-endpoint="<%= airport_suggestions_path(format: :json) %>">
                 <div class="dropdown w-full flex" data-target="airport-field.dropdownContainer">
                   <input type="text" class="input flex-1 mr-1" data-target="airport-field.searchField" data-action="input->airport-field#search blur->airport-field#select keydown->airport-field#keyboardNavigate blur->flight-footprint-form#update">
-                  <button type="button" class="button" data-action="airport-field#remove flight-footprint-form#update">
-                    <i class="fa fa-times" aria-hidden="true"></i>
+                  <button type="button" class="button flex items-center" data-action="airport-field#remove flight-footprint-form#update">
+                      <i class="material-icons-round" aria-hidden="true">close</i>
                   </button>
                   <ul class="dropdown-menu cursor-pointer" data-target="airport-field.suggestionsList airport-field.dropdownTrigger" data-active-class="dropdown-menu cursor-pointer block">
                   </ul>
@@ -60,8 +60,8 @@
                 <input type="hidden" name="outbound_connection_airports[]" data-target="airport-field.airportCodeField">
               </div>
               <div class="space-y-1" data-target="template-element.destination"></div>
-              <button type="button" class="button mt-3" data-action="template-element#cloneToDestination">
-                <i class="fa fa-plus" aria-hidden="true"></i>
+              <button type="button" class="button mt-3 flex items-center" data-action="template-element#cloneToDestination">
+                <i class="material-icons-round mr-1" aria-hidden="true">add</i>
                 <%=t 'views.flight_footprints.new.add_connection' %>
               </button>
             </div>
@@ -81,8 +81,8 @@
                 <div class="hidden" data-controller="airport-field" data-target="template-element.template airport-field.container" data-search-endpoint="<%= airport_suggestions_path(format: :json) %>">
                   <div class="dropdown w-full flex" data-target="airport-field.dropdownContainer">
                     <input type="text" class="input flex-1 mr-1" data-target="airport-field.searchField" data-action="input->airport-field#search blur->airport-field#select keydown->airport-field#keyboardNavigate blur->flight-footprint-form#update">
-                    <button type="button" class="button" data-action="airport-field#remove flight-footprint-form#update">
-                      <i class="fa fa-times" aria-hidden="true"></i>
+                    <button type="button" class="button flex items-center" data-action="airport-field#remove flight-footprint-form#update">
+                      <i class="material-icons-round" aria-hidden="true">close</i>
                     </button>
                     <ul class="dropdown-menu cursor-pointer" data-target="airport-field.suggestionsList airport-field.dropdownTrigger" data-active-class="dropdown-menu cursor-pointer block">
                     </ul>
@@ -90,8 +90,8 @@
                   <input type="hidden" name="return_connection_airports[]" data-target="airport-field.airportCodeField">
                 </div>
                 <div class="space-y-1" data-target="template-element.destination"></div>
-                <button type="button" class="button mt-3" data-action="template-element#cloneToDestination">
-                  <i class="fa fa-plus" aria-hidden="true"></i>
+                <button type="button" class="button mt-3 flex items-center" data-action="template-element#cloneToDestination">
+                <i class="material-icons-round mr-1" aria-hidden="true">add</i>
                   <%=t 'views.flight_footprints.new.add_connection' %>
                 </button>
               </div>

--- a/app/views/flight_offsets/new.html.erb
+++ b/app/views/flight_offsets/new.html.erb
@@ -84,15 +84,17 @@
               <div class="col-sm-7">
                 <div class="input" data-target="stripe-card-element.container"></div>
                 <div class="help-block text-warning hidden-when-empty" data-target="stripe-card-element.errors"></div>
-                <i class="fa fa-lock" aria-hidden="true"></i>
-                <span class="ml-1">Secured by Stripe</span>
+                <div class="flex items-center">
+                  <span class="material-icons-round" aria-hidden="true">lock</span>
+                  <span class="ml-1">Secured by Stripe</span>
+                </div>
               </div>
             </div>
 
             <p class="text-warning hidden-when-empty" data-target="checkout-form.errorMessage"></p>
 
-            <button type="submit" data-target="checkout-form.submitButton" class="button button-cta w-full">
-              <i class="fa fa-spinner fa-spin hidden" data-target="checkout-form.loadingIndicator"></i>
+            <button type="submit" data-target="checkout-form.submitButton" class="button button-cta w-full flex items-center justify-center">
+              <span class="material-icons-round mr-1 hidden" data-target="checkout-form.loadingIndicator">hourglass_bottom</span>
               <%=t 'views.flight_offsets.new.submit' %>
             </button>
 

--- a/app/views/gift_cards/new.html.erb
+++ b/app/views/gift_cards/new.html.erb
@@ -47,15 +47,18 @@
                 <%=t 'credit_or_debit_card' %>
               </label>
               <div class="input" data-target="stripe-card-element.container"></div>
-              <i class="fa fa-lock" aria-hidden="true"></i> <span class="ml-1">Secured by Stripe</span>
+              <div class="flex items-center">
+                <span class="material-icons-round" aria-hidden="true">lock</span>
+                <span class="ml-1">Secured by Stripe</span>
+              </div>
               <div class="help-block text-warning hidden-when-empty" data-target="stripe-card-element.errors"></div>
             </div>
 
             <p class="text-warning hidden-when-empty" data-target="checkout-form.errorMessage"></p>
             <%= f.hidden_field :number_of_months %>
 
-            <%= button_tag type: 'submit', 'data-target': 'checkout-form.submitButton', class: 'button button-cta w-full' do %>
-              <i class="fa fa-spinner fa-spin hidden" data-target="checkout-form.loadingIndicator"></i>
+            <%= button_tag type: 'submit', 'data-target': 'checkout-form.submitButton', class: 'button button-cta w-full flex items-center justify-center' do %>
+              <span class="material-icons-round mr-1 hidden" data-target="checkout-form.loadingIndicator">hourglass_bottom</span>
               <%= t('views.gift_cards.new.pay') %>
             <% end %>
           </div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -190,12 +190,12 @@
                 <%= image_tag webpack_asset_path(person[:image_url]), class: 'absolute top-0 w-full h-full object-cover', alt: "" %>
               </div>
             </div>
-            <div class="t:w-2/3 space-y-3">
-              <div class="text-3xl">
-                <i class="fa fa-quote-right" aria-hidden="true"></i>
+            <div class="t:w-2/3">
+              <div class="-ml-2 -mb-2">
+                <span class="material-icons-round text-5xl" aria-hidden="true">format_quote</span>
               </div>
               <p class="text-lg">”<%= t("views.welcome.index.community.people.#{person[:key]}.quote") %>”</p>
-              <p class="font-semibold text-center t:text-left">&mdash; <%= person[:name] %>, <%= t("views.welcome.index.community.people.#{person[:key]}.title") %></p>
+              <p class="font-semibold text-center t:text-left mt-3">&mdash; <%= person[:name] %>, <%= t("views.welcome.index.community.people.#{person[:key]}.title") %></p>
             </div>
           </div>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
     <% if (yield :javascripts).present? %>
       <link href="https://fonts.googleapis.com/css?family=Raleway:300" rel="stylesheet">
     <% else %>
-      <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+      <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Round" rel="stylesheet">
     <% end %>
 
     <% if Rails.env.development? %>

--- a/app/views/lifestyle_footprints/new.html.erb
+++ b/app/views/lifestyle_footprints/new.html.erb
@@ -15,23 +15,23 @@
               data-target="lifestyle-calculator.categoryIndicator"
               data-category="home"
             >
-              <i class="fa fa-lg fa-home" aria-hidden="true"></i>
+              <i class="material-icons-round" aria-hidden="true">home</i>
             </div>
             <div class="text-sm text-gray-accent">
               <% if @calculator.region_options.present? %>
-                <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></i>
+                <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></span>
               <% end %>
               <% if @calculator.home_options.present? %>
-                <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></i>
+                <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></span>
               <% end %>
               <% if @calculator.heating_options.present? %>
-                <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></i>
+                <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></span>
               <% end %>
               <% if @calculator.house_age_options.present? %>
-                <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></i>
+                <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></span>
               <% end %>
               <% if @calculator.green_electricity_options.present? %>
-                <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></i>
+                <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="home"></span>
               <% end %>
             </div>
           </div>
@@ -43,11 +43,11 @@
                 data-target="lifestyle-calculator.categoryIndicator"
                 data-category="food"
               >
-                <i class="fa fa-lg fa-cutlery" aria-hidden="true"></i>
+                <i class="material-icons-round" aria-hidden="true">restaurant</i>
               </div>
             <div class="text-sm text-gray-accent">
               <% if @calculator.food_options.present? %>
-                <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="food"></i>
+                <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="food"></span>
               <% end %>
             </div>
             </div>
@@ -59,12 +59,12 @@
                 data-target="lifestyle-calculator.categoryIndicator"
                 data-category="car"
               >
-                <i class="fa fa-lg fa-car" aria-hidden="true"></i>
+                <i class="material-icons-round" aria-hidden="true">directions_car</i>
               </div>
               <div class="text-sm text-gray-accent">
                 <% if @calculator.car_type_options.present? %>
-                  <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="car"></i>
-                  <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="car"></i>
+                  <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="car"></span>
+                  <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="car"></span>
                 <% end %>
               </div>
             </div>
@@ -75,10 +75,10 @@
               data-target="lifestyle-calculator.categoryIndicator"
               data-category="flights"
             >
-              <i class="fa fa-lg fa-plane" aria-hidden="true"></i>
+              <i class="material-icons-round" aria-hidden="true">flight</i>
             </div>
             <div class="text-sm text-gray-accent">
-                <i class="fa fa-circle-o" data-active-class="fa fa-circle text-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="flights"></i>
+                <span class="w-3 h-3 inline-block rounded-full border-2 border-gray-accent bg-none" data-active-class="w-3 h-3 inline-block rounded-full border-2 bg-green-accent border-green-accent" data-target="lifestyle-calculator.questionIndicator" data-category="flights"></span>
             </div>
           </div>
         </div>
@@ -195,10 +195,10 @@
 
         <% end %>
 
-        <div class="flex justify-space-between">
-          <div class="hidden cursor-pointer" data-target="lifestyle-calculator.back" data-action="click->lifestyle-calculator#previousCategory">
-            <i class="fa fa-chevron-left" aria-hidden="true"></i>
-            <span><%=t 'views.lifestyle_footprints.back' %></span>
+        <div class="text-left">
+          <div class="inline-flex items-center hidden cursor-pointer" data-target="lifestyle-calculator.back" data-action="click->lifestyle-calculator#previousCategory">
+            <span class="material-icons-round" aria-hidden="true">arrow_back</span>
+            <span class="ml-1"><%=t 'views.lifestyle_footprints.back' %></span>
           </div>
         </div>
       </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -79,7 +79,7 @@
         <label for="project-<%= project.id %>" class="p-4 flex items-center cursor-pointer space-x-4">
           <img class="h-16 w-16 rounded-full object-cover" src="<%= project.image_url %>">
           <h2 class="flex-grow font-bold"><%= project.name %>, <%= project.country %></h2>
-          <span class="fa fa-chevron-down transform toggler-checked:rotate-180 transition-transform duration-200"></span>
+          <span class="material-icons-round transform toggler-checked:rotate-180 transition-transform duration-200">expand_more</span>
         </label>
         <div class="hidden toggler-checked:block px-4 pb-4">
           <div class="max-w-2xl">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -64,7 +64,7 @@
         <label for="region-picker" class="button button-inverted flex items-center">
           <%= image_tag webpack_asset_path("images/regions/#{current_region.id}.png"), alt: '' %>
           <span class="ml-2"><%= current_region.name %></span>
-          <i class="fa fa-caret-up ml-2" aria-hidden="true"></i>
+          <i class="material-icons-round ml-2" aria-hidden="true">expand_less</i>
         </label>
         <ul class="dropdown-menu dropdown-menu-up">
           <% Region.all.filter { |r| r != current_region }.each do |region| %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,9 +25,9 @@
               <% if user_signed_in? %> 
                 <div class="d:dropdown"> 
                   <input type="checkbox" id="user-menu" class="dropdown-toggler">
-                  <label for="user-menu" class="button hidden d:block" aria-haspopup="true" aria-expanded="false">
+                  <label for="user-menu" class="button hidden d:flex d:items-center" aria-haspopup="true" aria-expanded="false">
                     <%= current_user.user_name.nil? || current_user.user_name.empty? ? current_user.email : current_user.user_name %>
-                    <i class="fa fa-caret-down" aria-hidden="true"></i>
+                    <i class="material-icons-round ml-2" aria-hidden="true">expand_more</i>
                   </label> 
                   <ul class="d:dropdown-menu d:dropdown-menu-right space-y-4 d:space-y-0" aria-labelledby="user-menu"> 
                     <li><%= link_to 'Dashboard', dashboard_path, class: 'link-ui' %></li>
@@ -49,8 +49,8 @@
         <%= link_to(I18n.t('views.shared.header.sign_up'), root_url, class: 'button button-cta')%>
       <% end %>
 
-      <label for="nav-toggler" class="button d:hidden">
-        <i class="fa fa-bars"></i>
+      <label for="nav-toggler" class="button flex d:hidden">
+        <i class="material-icons-round" aria-hidden="true">menu</i>
       </label>
     </nav>
   </div>
@@ -67,8 +67,8 @@
           <%=t 'views.shared.header.region_recommendation.continue_button', region: region.name %>
         <% end %>
       </div>
-      <button id="region-recommendation-dismiss" class="pl-4" aria-label="<%= t 'views.shared.header.region_recommendation.dismiss' %>">
-        <i class="fa fa-times fa-lg" aria-hidden="true"></i>
+      <button id="region-recommendation-dismiss" class="pl-4 font-lg" aria-label="<%= t 'views.shared.header.region_recommendation.dismiss' %>">
+        <i class="material-icons-round" aria-hidden="true">close</i>
       </button>
     </div>
     <script>
@@ -86,11 +86,17 @@
 <% end %>
 
 <% if notice || alert %>
-  <div id="alert" class="p-4 t:px-8 text-center bg-primary text-white" role="alert">
+  <div id="alert" class="p-4 t:px-8 bg-primary text-white" role="alert">
     <% if notice %>
-      <p><span class="fa fa-exclamation-circle"></span> <%= notice %></p>
+      <p class="flex items-center justify-center">
+        <i class="material-icons-round mr-1" aria-hidden="true">error</i>
+        <%= notice %>
+      </p>
     <% elsif alert %>
-      <p><span class="fa fa-exclamation-triangle"></span> <%= alert %></p>
+      <p class="flex items-center justify-center">
+        <i class="material-icons-round mr-1" aria-hidden="true">warning</i>
+        <%= alert %>
+      </p>
     <% end %>
   </div>
   <% content_for :javascript_tags do %>


### PR DESCRIPTION
## Let's keep this PR open until it's been thoroughly discussed

Stylewise, this is a change we want to do. However, there are some differences in implementing the icons that could be taken into account, and also the reason for leaving this as a PR without merging.

### Things to consider

1. Material icons align differently with text than FA icons, which requires additional markup to solve. As can be seen in the changes, I've done it with adding `flex items-center` to the parent element.
2. Sizing. Material Icon's base size is 24px, and is set through the icon font class, which means it's unaffected by utility classes that affect font size, without CSS fixes. [Material icons](https://google.github.io/material-design-icons/#styling-icons-in-material-design) suggest size steps of either 18, 24, 36 or 48px. 
3. Not all Material icons fill up their space in the same way, making it difficult and honestly pretty frustrating to align them. For instance, I was about the change the quote as seen below. There were basically no issues when using FA, but here with Material icons I have to dab around with minus margin to make the icon line up with the text to the left.
![Screenshot 2020-07-10 at 10 23 53](https://user-images.githubusercontent.com/8473077/87133531-c6d63a00-c297-11ea-905a-6e4ce035ff8f.png)
4. As Material Icons doesn't include social media icons, social icons have not been replaced, and we either need to keep Font Awesome or implement some other solution to handle social media icons.

In summary, I'm actually leaning towards NOT going over to Material icons, mainly due to the overhand in actually using them. To me, we use icons so rarely that they are barely visible, and then there is not a big reason for me to a) add more to our bundle size and b) slow down the implementation of icons. 

### Notes

- Where icons have been used in templates with old designs, the icons have not been replaced with Material icons