### PR TITLE
New design dashboard

### DIFF
--- a/app/assets/main/components/lists.scss
+++ b/app/assets/main/components/lists.scss
@@ -29,3 +29,19 @@
       pl-8;
   }
 }
+
+.list-number {
+  counter-reset: my-list;
+
+  li {
+    counter-increment: my-list;
+  }
+
+  li::before {
+    content: counter(my-list) ". ";
+
+    @apply
+      font-semibold
+      mr-1;
+  }
+}

--- a/app/views/dashboard/show_new.html.erb
+++ b/app/views/dashboard/show_new.html.erb
@@ -1,0 +1,135 @@
+<%= render "shared/facebook_script" %>
+<%= render "shared/twitter_script" %>
+
+<%= render "shared/header" %>
+
+<div class="bg-blue-pastel">
+  <section class="section-padding">
+    <h2 class="heading-xl mb-12"><%= t 'dashboard.heading' %></h2>
+
+    <div class="callout max-w-4xl mx-auto">
+      <div class="section-gutter flex flex-col t:flex-row">
+        <div class="t:w-1/2 text-center space-y-2">
+          <p class="font-bold"><%= t 'dashboard.your_months' %></p>
+          <p class="text-3xl font-bold text-green-accent">
+            <%= @my_neutral_months %>
+            <% if @my_neutral_months == 1 %>
+              <%=t 'months.one' %>
+            <% else %>
+              <%=t 'months.other' %>
+            <% end %>
+          </p>
+        </div>
+        <div class="t:w-1/2 text-center space-y-2">
+          <p class="font-bold"><%= t 'dashboard.your_offsets' %></p>
+          <p class="text-3xl font-bold text-green-accent">
+            <%= number_with_delimiter(@my_carbon_offset) %>
+            <%=t 'tonnes' %>
+          </p>
+        </div>
+      </div>
+
+      <div class="text-center mt-12">
+        <%= raw(t('dashboard.together', number_of_members: @unique_climate_neutral_users, number_of_tonnes: number_with_delimiter(@total_carbon_offset)).gsub('<span>', '<span class="font-bold">')) %>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-padding">
+    <div class="section-gutter t:flex t:flex-row">
+      <div class="t:w-1/2">
+        <h3 class="heading-lg mb-3"><%=t 'cimate_hero_toplist' %></h3>
+        <ol class="list-number space-y-1">
+          <% @user_top_list.each_with_index do |user, index| %>
+            <% user_neutral_months = user.count %>
+            <% user_name = user.user_name || "Unknown User" %>
+
+            <% if index == 10 %>
+              <input type="checkbox" id="user-toplist-toggler" class="toggler">
+              <div class="hidden toggler-checked:block space-y-1">
+            <% end %>
+
+            <li class="text-left<%= user.id == current_user.id ? " font-bold inline-block bg-green-accent text-white py-1 px-2 -ml-2 rounded" : "" %>">
+              <%= user_name %> (<%= user_neutral_months %> <%=t 'climate_neutral_months', count: user_neutral_months %>)
+            </li>
+
+            <% if @user_top_list.length > 10 && index == (@user_top_list.length - 1) %>
+              </div>
+              <div class="toggler-checked:hidden pt-3">
+                <label for="user-toplist-toggler" class="link cursor-pointer"><%= t 'show_full_toplist' %></label>
+              </div>
+              <div class="toggler-not-checked:hidden toggler-checked:block pt-3">
+                <label for="user-toplist-toggler" class="link cursor-pointer"><%= t 'hide_full_toplist' %></label>
+              </div>
+            <% end %>
+          <% end %>
+        </ol>
+      </div>
+      <div class="t:w-1/2">
+        <h3 class="heading-lg mb-3"><%=t 'climate_country_toplist' %></h3>
+        <ol class="list-number space-y-1">
+          <% @country_top_list.each_with_index do |country, index| %>
+            <% country_name = country.country_name || "Unknown" %>
+
+            <% if index == 10 %>
+              <input type="checkbox" id="country-toplist-toggler" class="toggler">
+              <div class="hidden toggler-checked:block space-y-1">
+            <% end %>
+
+            <li class="text-left<%= country_name == current_user.country_name ? " font-bold inline-block bg-green-accent text-white py-1 px-2 -ml-2 rounded" : "" %>">
+              <%= country_name %> (<%= country.count %> <%=t 'climate_neutral_months', count: country.count %>)
+            </li>
+
+            <% if @user_top_list.length > 10 && index == (@user_top_list.length - 1) %>
+              </div>
+              <div class="toggler-checked:hidden pt-3">
+                <label for="country-toplist-toggler" class="link cursor-pointer"><%= t 'show_full_toplist' %></label>
+              </div>
+              <div class="toggler-not-checked:hidden toggler-checked:block pt-3">
+                <label for="country-toplist-toggler" class="link cursor-pointer"><%= t 'hide_full_toplist' %></label>
+              </div>
+            <% end %>
+          <% end %>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-padding">
+    <h2 class="heading-lg"><%=t 'views.projects.latest_projects' %></h2>
+
+    <div class="mt-12 flex flex-col d:flex-row section-gutter">
+      <% @projects.take(3).each do |project| %>
+        <div class="d:w-1/3 pt-20 m-lg:pt-24">
+          <div class="callout h-full space-y-3 pt-0">
+            <div class="inline-block w-full">
+              <img class="mx-auto h-40 w-40 -mt-20 m-lg:h-48 m-lg:w-48 m-lg:-mt-24 rounded-full object-cover" src="<%= project.image_url %>">
+            </div>
+            <h3 class="heading"><%= project.name %></h3>
+            <%= simple_format(project.short_description) %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="mt-12 text-center">
+      <%= link_to t('views.projects.see_all'), projects_path, class: 'button' %>
+    </div>
+  </section>
+
+  <section class="section-padding space-y-3 d:w-2/3">
+    <h3 class="heading-lg mb-6">
+      <%=t 'you_have_lived_climate_neutral_for', count: @my_neutral_months %>
+      <%=t 'good_job' %>
+    </h3>
+    <p><%=t 'climate_change_is_best_faced_together' %></p>
+    <div class="flex flex-col m-lg:flex-row m-lg:space-x-3 space-y-3 m-lg:space-y-0">
+      <a class="button" id="share-facebook-bottom"><span class="fa fa-facebook"></span> <%=t 'share_on_facebook' %></a>
+      <a class="button" href="https://twitter.com/intent/tweet?text=<%= encoded_social_quote(@my_neutral_months) %>" data-size="large"><span class="fa fa-twitter"></span> <%=t 'share_on_twitter' %></a>
+    </div>
+  </section>
+
+  <%= render "shared/bottom_landscape" %>
+</div>
+
+<%= render "shared/footer", skip_prefooter: true %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,7 @@
 <footer>
-  <%= render "shared/prefooter" %>
+  <% if !local_assigns[:skip_prefooter] %>
+    <%= render "shared/prefooter" %>
+  <% end %>
 
   <section class="bg-primary text-white text-sm p-4 py-6 t:px-8 t:py-12 space-y-4">
     <div class="flex flex-row flex-wrap -m-4">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,11 @@ en:
   climate_change_is_best_faced_together: You are awesome! Since climate change is best faced together, it would be great if you want to share the message so that more people can start living climate neutral lives!
   share_on_facebook: Share on Facebook
   share_on_twitter: Share on Twitter
+  dashboard:
+    heading: Hello, climate friend!
+    your_months: You have been climate neutral for
+    your_offsets: Your CO2 offsets add up to
+    together: Together with all <span>%{number_of_members} members</span>, we have prevented <span>%{number_of_tonnes} tonnes</span> of CO2 from reaching the atmosphere!
   we_have_accomplished_alot_together: We have accomplished a lot together!
   amount_of_carbon_we_have_offset: Number of tonnes CO2 that we have offset together
   amount_of_carbon_i_have_offset: Number of tonnes CO2 that you have offset so far
@@ -123,8 +128,8 @@ en:
   date_of_our_investment: Date of Investment
   read_more: More info
   cimate_hero_toplist: Climate Hero Toplist
-  show_full_toplist: Show Full Toplist
-  hide_full_toplist: Hide Full Toplist
+  show_full_toplist: Show full toplist
+  hide_full_toplist: Hide full toplist
   climate_neutral_months:
     one: climate neutral month
     other: climate neutral months

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -104,6 +104,11 @@ sv:
   climate_change_is_best_faced_together: Du är en hjälte! Bäst bromsar vi klimatförändringarna tillsammans, så dela gärna det här så att vi blir fler som lever klimatneutralt!
   share_on_facebook: Dela på Facebook
   share_on_twitter: Dela på Twitter
+  dashboard:
+    heading: Hej, klimatvän!
+    your_months: Du har varit klimatneutral i
+    your_offsets: Antal undvikna ton koldioxidutsläpp
+    together: Tillsammans med alla <span>%{number_of_members} medlemmar</span> har vi förhindrat <span>%{number_of_tonnes} ton</span> koldioxid från att nå atmosfären!
   we_have_accomplished_alot_together: Vi har åstadkommit mycket tillsammans!
   amount_of_carbon_we_have_offset: Antal ton CO2 vi har bidragit till att minska tillsammans
   amount_of_carbon_i_have_offset: Antal ton CO2 som du har minskat utsläpp av
@@ -126,7 +131,7 @@ sv:
   climate_neutral_months:
     one: klimatneutral månad
     other: klimatneutrala månader
-  climate_country_toplist: Topplista klimatneutrala länder
+  climate_country_toplist: Topplista klimatländer
   total_carbon_offset_by_us: Totalt har vi minskat utsläpp på
   read_more_about_investments_on_our_blog: 'Läs mer om projekten vi investerar i på vår blogg >>'
   tonnes_CO2: ton CO2

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Sessions', type: :feature, js: true do
       click_link('Log out')
     end
     # Homepage
-    visit '/'
+    visit '/?disable_experiments=new_design'
     click_link 'Log In'
 
     # sign in page


### PR DESCRIPTION
## Notes

- Blue background to a) separate from public pages and b) green became too much green
- Fewer colour changes in the "You have been climate neutral for 1 month" text to keep it less all over the place/give it more harmony
- Possibility to add illustration to Share section
- The footer is used here, but with added possibility of skipping the prefooter, as the person is already logged in and don't need to sign up

![Screenshot 2020-07-09 at 08 31 12](https://user-images.githubusercontent.com/8473077/87005126-d33a9400-c1be-11ea-9dfe-2fce549a7e2b.png)
![Screenshot 2020-07-09 at 08 31 23](https://user-images.githubusercontent.com/8473077/87005132-d3d32a80-c1be-11ea-90d5-b95ecc617d5b.png)
![Screenshot 2020-07-09 at 08 31 32](https://user-images.githubusercontent.com/8473077/87005134-d46bc100-c1be-11ea-98f3-ef501348536d.png)
![Screenshot 2020-07-09 at 08 31 41](https://user-images.githubusercontent.com/8473077/87005136-d46bc100-c1be-11ea-8570-1d48241e02be.png)
