### PR TITLE
New design on error pages

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,12 +1,12 @@
 <%= render "shared/header" %>
-  <section class="section-padding text-center">
-    <div class="callout">
-      <h1 class="text-4xl font-bold my-6">An error occurred on our side <i class="fa fa-frown-o" aria-hidden="true"></i></h1>
-      <div class="space-y-3">
-        <p>We're sorry, but an error occured on our side. We have been notified about it and will look into it as soon as possible. Please try again in a few moments.</p>
-        <p>If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com', class: 'link' %>.</p>
-      </div>
-    </div>
-  </section>
-<%= render "shared/footer" %>
+
+<section class="section-padding min-h-1/2-screen flex items-center">
+  <div class="max-w-xl mx-auto space-y-3">
+    <h1 class="heading-lg">An error occurred on our side</h1>
+    <p>We're sorry, but an error occured on our side. We have been notified about it and will look into it as soon as possible. Please try again in a few moments.</p>
+    <p>If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com', class: 'link' %>.</p>
+  </div>
+</section>
+
+<%= render "shared/footer", skip_prefooter: true %>
 

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,22 +1,12 @@
-<% content_for :stylesheets do %>
-  <%= webpack_entrypoint_stylesheet_tags 'main_old' %>
-<% end %>
-<% content_for :javascripts do %>
-  <%= webpack_entrypoint_javascript_tags 'main_old', onerror: 'reportLoadError(event)' %>
-<% end %>
+<%= render "shared/header" %>
+  <section class="section-padding text-center">
+    <div class="callout">
+      <h1 class="text-4xl font-bold my-6">An error occurred on our side <i class="fa fa-frown-o" aria-hidden="true"></i></h1>
+      <div class="space-y-3">
+        <p>We're sorry, but an error occured on our side. We have been notified about it and will look into it as soon as possible. Please try again in a few moments.</p>
+        <p>If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com', class: 'link' %>.</p>
+      </div>
+    </div>
+  </section>
+<%= render "shared/footer" %>
 
-<div class="site-wrapper-first">
-  <%= render "shared/header_old" %>
-  <div class="inner">
-
-    <h1>An error occurred on our side</h1>
-    <p>
-    We're sorry, but an error occured on our side. We have been notified about it and will look into it as soon as possible. Please try again in a few moments.<br>
-    <br>
-    If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com' %>.
-    </p>
-
-  </div>
-</div>
-
-<%= render "shared/footer_old" %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,18 +1,8 @@
-<% content_for :stylesheets do %>
-  <%= webpack_entrypoint_stylesheet_tags 'main_old' %>
-<% end %>
-<% content_for :javascripts do %>
-  <%= webpack_entrypoint_javascript_tags 'main_old', onerror: 'reportLoadError(event)' %>
-<% end %>
-
-<div class="site-wrapper-first">
-  <%= render "shared/header_old" %>
-  <div class="inner">
-
-    <h1>Page not found</h1>
-    <p>We're sorry, but we can't find that page.</p>
-
-  </div>
-</div>
-
-<%= render "shared/footer_old" %>
+<%= render "shared/header" %>
+  <section class="section-padding text-center">
+    <div class="callout">
+      <h1 class="text-4xl font-bold my-6">Page not found <i class="fa fa-meh-o" aria-hidden="true"></i></h1>
+      <p class="">We're sorry, but we can't find that page.</p>
+    </div>
+  </section>
+<%= render "shared/footer" %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,8 +1,10 @@
 <%= render "shared/header" %>
-  <section class="section-padding text-center">
-    <div class="callout">
-      <h1 class="text-4xl font-bold my-6">Page not found <i class="fa fa-meh-o" aria-hidden="true"></i></h1>
-      <p class="">We're sorry, but we can't find that page.</p>
-    </div>
-  </section>
-<%= render "shared/footer" %>
+
+<section class="section-padding min-h-1/2-screen flex items-center">
+  <div class="max-w-xl mx-auto text-center space-y-3">
+    <h1 class="heading-lg">Page not found</h1>
+    <p class="t:text-lg">We're sorry, but we can't find that page.</p>
+  </div>
+</section>
+
+<%= render "shared/footer", skip_prefooter: true %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,11 +1,11 @@
 <%= render "shared/header" %>
-  <section class="section-padding text-center">
-    <div class="callout">
-      <h1 class="text-4xl font-bold my-6">There was an error processing your request <i class="fa fa-frown-o" aria-hidden="true"></i></h1>
-      <div class="space-y-3">
-        <p>We're sorry, but something your browser sent to us was not in the format we expected it to be. Please try again.</p>
-        <p>If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com', class: 'link' %>.</p>
-      </div>
-    </div>
-  </section>
-<%= render "shared/footer" %>
+
+<section class="section-padding min-h-1/2-screen flex items-center">
+  <div class="max-w-xl mx-auto space-y-3">
+    <h1 class="heading-lg">There was an error processing your request</h1>
+    <p>We're sorry, but something your browser sent to us was not in the format we expected it to be. Please try again.</p>
+    <p>If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com', class: 'link' %>.</p>
+  </div>
+</section>
+
+<%= render "shared/footer", skip_prefooter: true %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,22 +1,11 @@
-<% content_for :stylesheets do %>
-  <%= webpack_entrypoint_stylesheet_tags 'main_old' %>
-<% end %>
-<% content_for :javascripts do %>
-  <%= webpack_entrypoint_javascript_tags 'main_old', onerror: 'reportLoadError(event)' %>
-<% end %>
-
-<div class="site-wrapper-first">
-  <%= render "shared/header_old" %>
-  <div class="inner">
-
-    <h1>There was an error processing your request</h1>
-    <p>
-    We're sorry, but something your computer sent to us was not in the format we expected it to be. Please try again.<br>
-    <br>
-    If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com' %>.
-    </p>
-
-  </div>
-</div>
-
-<%= render "shared/footer_old" %>
+<%= render "shared/header" %>
+  <section class="section-padding text-center">
+    <div class="callout">
+      <h1 class="text-4xl font-bold my-6">There was an error processing your request <i class="fa fa-frown-o" aria-hidden="true"></i></h1>
+      <div class="space-y-3">
+        <p>We're sorry, but something your browser sent to us was not in the format we expected it to be. Please try again.</p>
+        <p>If you have any questions, please don't hesitate to get in touch with us at <%= link_to 'hello@goclimate.com', 'mailto:hello@goclimate.com', class: 'link' %>.</p>
+      </div>
+    </div>
+  </section>
+<%= render "shared/footer" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
   </head>
 
   <%# TODO: Change text-green-dark to text-primary when Bootstrap is gone. These apply to both new and old worlds, so text-primary clashes because it exists in both. %>
-  <body class="<%= controller_name + " " + controller_name + "-" + action_name %> min-h-screen text-base text-green-dark bg-yellow-pastel">
+  <body class="<%= controller_name + " " + controller_name + "-" + action_name %> min-h-screen text-base text-green-dark bg-primary">
 
     <% if params[:registered].to_i == 1 %>
       <script>
@@ -90,7 +90,9 @@
       </script>
     <% end %>
 
-    <%= yield %>
+    <div class="bg-yellow-pastel">
+      <%= yield %>
+    </div>
 
     <script>
       function reportLoadError(event) {

--- a/app/views/shared/_prefooter.html.erb
+++ b/app/views/shared/_prefooter.html.erb
@@ -1,4 +1,4 @@
-<section class="z-0 mt-16 d-md:32">
+<section class="relative z-0 mt-16 d-md:32">
   <div class="relative max-w-3xl mx-auto py-10 px-10 d:px-0 text-center space-y-3 z-0">
     <h3 class="heading-lg mb-6"><%= t('views.shared.prefooter.heading') %></h3>
     <p><%= t('views.shared.prefooter.body_text') %> </p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -149,6 +149,9 @@ module.exports = {
         0: 0,
         ...theme('spacing')
       }),
+      minHeight: {
+        '1/2-screen': '50vh'
+      },
       maxWidth: {
         xs: '15rem',
         '1/4': '25%',


### PR DESCRIPTION
Super quick and easy translation of new design onto error pages.

![Screenshot 2020-08-21 at 09 22 34](https://user-images.githubusercontent.com/8473077/90864030-40ca0a80-e390-11ea-80ca-f67cbe4eeb76.png)

![Screenshot 2020-08-21 at 09 22 08](https://user-images.githubusercontent.com/8473077/90864022-3dcf1a00-e390-11ea-9ff0-637b48303c0a.png)
![Screenshot 2020-08-21 at 09 22 26](https://user-images.githubusercontent.com/8473077/90864027-3f004700-e390-11ea-8ed0-0d353ce9029a.png)
