### PR TITLE
Remove Google tag manager tracking

### DIFF
--- a/app/views/application/_third_party_javascripts.html.erb
+++ b/app/views/application/_third_party_javascripts.html.erb
@@ -33,7 +33,6 @@
 <% if client_prefers_no_tracking? %>
   <script>
     function ga() {}
-    function gtag() {}
     function fbq() {}
   </script>
 <% else %>
@@ -46,15 +45,6 @@
     <% unless ENV['GOOGLE_ANALYTICS_SENDING'] == 'enabled' %>ga('set', 'sendHitTask', null);<% end %>
     ga('set', 'dimension1', '<%= @active_experiments.any? ? @active_experiments.sort.join(',') : 'none' %>');
     ga('send', 'pageview');
-  </script>
-
-  <!-- Global site tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-823228700"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'AW-823228700');
   </script>
 
   <!-- Facebook Pixel Code -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,13 +59,9 @@
   <%# TODO: Change text-green-dark to text-primary when Bootstrap is gone. These apply to both new and old worlds, so text-primary clashes because it exists in both. %>
   <body class="<%= controller_name + " " + controller_name + "-" + action_name %> min-h-screen text-base text-green-dark bg-green-dark">
 
-    <!-- TODO: Will be fixed and tested further on
     <% if params[:registered].to_i == 1 %>
       <script>
         fbq('track', 'signed_up_without_subscription');
-        gtag('event', 'signed_up_without_subscription', {
-          'send_to': 'AW-823228700/-nQJCJXUrrcBEJzyxYgD',
-        });
         ga('send',
           'event',
           'sign_up',
@@ -73,17 +69,11 @@
           );
       </script>
     <% end %>
-    -->
     <% if params[:subscribed].to_i == 1 %>
       <script>
         fbq('track', 'Purchase', {
           currency: "<%= current_region.currency %>",
           value: <%= current_user.subscription_amount %>
-        });
-        gtag('event', 'conversion', {
-          'send_to': 'AW-823228700/-nQJCJXUrrcBEJzyxYgD',
-          'value': <%= current_user.subscription_amount %>,
-          'currency': '<%= current_region.currency %>'
         });
         ga('send',
           'event',


### PR DESCRIPTION
After discussions with @kallenilver we have decided to remove Google Tag Manager as it is not being used and not really relevant for our site. 

Regarding the tracking of local events or not - I have chosen to keep the scope on our current focus and added a card for handling local tracking later on https://trello.com/c/ZboMkrD4 - as it's not something that is being introduced now, rather an issue we have had since who knows.

@stefanlindbohm did you want some other sort of testing for this or is it fine to keep an eye on our tracking services in production?