### PR TITLE
Add referral codes to sign up page

### DIFF
--- a/app/assets/main/controllers/referral_code_controller.js
+++ b/app/assets/main/controllers/referral_code_controller.js
@@ -1,0 +1,61 @@
+import { Controller } from 'stimulus';
+import submitForm from '../../util/submit_form';
+import { swapToActiveClassList, swapToInactiveClassList } from '../../util/swap_classes';
+
+class ReferralCodeNotFoundError extends Error { }
+
+export default class ReferralCodeController extends Controller {
+  submit(event) {
+    event.preventDefault();
+
+    this.setErrorMessage('');
+
+    if (this.formTarget.elements.code.value === '') {
+      this.formPresentedCheckboxTarget.checked = false;
+      this.deactivateCode();
+      return;
+    }
+
+    submitForm(this.formTarget)
+      .then((response) => {
+        if (!response.ok) {
+          throw new ReferralCodeNotFoundError();
+        }
+
+        return response.json();
+      })
+      .then((data) => {
+        this.activateCode(data.code);
+        this.formPresentedCheckboxTarget.checked = false;
+      })
+      .catch((error) => {
+        if (error instanceof ReferralCodeNotFoundError) {
+          this.setErrorMessage("That's not right, try again");
+          return;
+        }
+
+        window.Sentry.captureException(error); // These errors are unexpected, so report them.
+        this.setErrorMessage('An unexpected error occurred. Please start over and try again. If the issue remains, please contact us at hello@goclimate.com.');
+      });
+  }
+
+  activateCode(code) {
+    this.activeCodeTargets.forEach((target) => { target.innerText = code; });
+    this.activeCodeFieldTargets.forEach((target) => { target.value = code; });
+    this.codeActiveInfoTargets.forEach((target) => swapToActiveClassList(target));
+    this.noCodeActiveInfoTargets.forEach((target) => swapToInactiveClassList(target));
+  }
+
+  deactivateCode() {
+    this.activeCodeTargets.forEach((target) => { target.innerText = ''; });
+    this.activeCodeFieldTargets.forEach((target) => { target.value = ''; });
+    this.codeActiveInfoTargets.forEach((target) => swapToInactiveClassList(target));
+    this.noCodeActiveInfoTargets.forEach((target) => swapToActiveClassList(target));
+  }
+
+  setErrorMessage(message) {
+    this.errorMessageTarget.innerText = message;
+  }
+}
+
+ReferralCodeController.targets = ['form', 'formPresentedCheckbox', 'activeCode', 'activeCodeField', 'codeActiveInfo', 'noCodeActiveInfo', 'errorMessage'];

--- a/app/assets/main/controllers/registration_form_controller.js
+++ b/app/assets/main/controllers/registration_form_controller.js
@@ -57,13 +57,13 @@ export default class RegistrationFormController extends Controller {
           window.location = data.success_url;
           resolve();
           break;
-        case 'verification_required':
-          window.stripe.confirmCardPayment(data.payment_intent_client_secret)
+        case 'confirmation_required':
+          RegistrationFormController.confirmPromise(data.intent_type, data.intent_client_secret)
             .then((result) => {
-              if (result.paymentIntent !== undefined) {
-                window.location = data.success_url;
-              } else {
+              if (result.error !== undefined) {
                 this.setErrorMessage(result.error.message);
+              } else {
+                window.location = data.success_url;
               }
               resolve();
             });
@@ -103,5 +103,18 @@ export default class RegistrationFormController extends Controller {
     return this.application.getControllerForElementAndIdentifier(this.stripeCardElementTarget, 'stripe-card-element');
   }
 }
+
+RegistrationFormController.confirmPromise = function confirmPromise(
+  intentType, intentClientSecret
+) {
+  switch (intentType) {
+    case 'payment_intent':
+      return window.stripe.confirmCardPayment(intentClientSecret);
+    case 'setup_intent':
+      return window.stripe.confirmCardSetup(intentClientSecret);
+    default:
+      return null;
+  }
+};
 
 RegistrationFormController.targets = ['form', 'privacyPolicyAgreement', 'submitButton', 'stripeCardElement', 'errorMessage', 'loadingIndicator'];

--- a/app/controllers/referral_codes_controller.rb
+++ b/app/controllers/referral_codes_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReferralCodesController < ApplicationController
+  def lookup
+    code = ReferralCode.find_by!('LOWER(code) = ?', params[:code]&.downcase || '')
+
+    render json: { code: code.code }
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+end

--- a/app/controllers/users/subscriptions_controller.rb
+++ b/app/controllers/users/subscriptions_controller.rb
@@ -55,7 +55,7 @@ module Users
     end
 
     def set_subscription_manager
-      @manager = SubscriptionManager.new(current_user.stripe_customer)
+      @manager = SubscriptionManager.new(current_user)
     end
 
     def render_successful_update
@@ -91,14 +91,14 @@ module Users
     end
 
     def customer_currency
-      Currency.from_iso_code(@manager.customer.currency) || current_region.currency
+      Currency.from_iso_code(current_user.stripe_customer.currency) || current_region.currency
     end
 
     def customer_payment_method
-      if (payment_method_id = @manager.customer.invoice_settings&.default_payment_method)
+      if (payment_method_id = current_user.stripe_customer.invoice_settings&.default_payment_method)
         Stripe::PaymentMethod.retrieve(payment_method_id)
-      elsif (source_id = @manager.customer.default_source)
-        @manager.customer.sources.find { |s| s.id == source_id }
+      elsif (source_id = current_user.stripe_customer.default_source)
+        current_user.stripe_customer.sources.find { |s| s.id == source_id }
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,13 @@ class User < ApplicationRecord
   attr_accessor :privacy_policy
 
   def stripe_customer
-    Stripe::Customer.retrieve(stripe_customer_id) if stripe_customer_id.present?
+    if stripe_customer_id.present?
+      Stripe::Customer.retrieve(stripe_customer_id)
+    else
+      Stripe::Customer.create(email: email).tap do |c|
+        update_attribute(:stripe_customer_id, c.id)
+      end
+    end
   end
 
   def subscription_amount

--- a/app/views/devise/registrations/_sign_up_form_without_subscription.html.erb
+++ b/app/views/devise/registrations/_sign_up_form_without_subscription.html.erb
@@ -1,6 +1,6 @@
 <div class="callout max-w-md mx-auto" data-controller="registration-form membership-choice">
   <a id="sign-up" class="absolute -mt-32"></a>
-  <div class="space-y-3" data-controller="registration-price" data-target="membership-choice.priceControllerElement">
+  <div class="space-y-3" data-controller="registration-price referral-code" data-target="membership-choice.priceControllerElement">
     <h2 class="text-lg d:text-xl font-semibold text-center"><%= t 'views.registrations.sign_up_heading' %></h2>
     <p class="text-sm text-center mb-6 hidden"><%= t 'views.registrations.step' %> 1/2</p>
     <p class="text-center"><%= t 'views.registrations.sign_up_description' %></p>
@@ -45,17 +45,44 @@
         <% end %>
         <div class="h-px w-full bg-gray-tint-2 hidden"></div>
 
-        <div class="py-6 space-y-1">
-          <p class="heading-lg text-center">
-            <span data-target="membership-choice.subscriptionInfo" data-active-class="inline" data-inactive-class="hidden">
-              <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
-            </span>
-            <span class="hidden" data-target="membership-choice.noSubscriptionInfo" data-active-class="inline" data-inactive-class="hidden"><%= t 'views.registrations.price_free' %></span>
-          </p>
+        <div data-target="membership-choice.subscriptionInfo" data-inactive-class="hidden">
+          <div class="mt-3 collapse">
+            <input type="checkbox" id="enter_referral_code" data-target="referral-code.formPresentedCheckbox" class="hidden">
+            <div data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden">
+              <p class="text-center text-sm"><%=t 'views.registrations.referral_code' %>: <strong data-target="referral-code.activeCode" class="mr-1"></strong> <label for="enter_referral_code" class="link cursor-pointer"><%=t 'views.registrations.referral_code_change' %></label></p>
+            </div>
+            <div data-target="referral-code.noCodeActiveInfo" data-inactive-class="hidden">
+              <p class="text-center text-sm"><label for="enter_referral_code" class="link cursor-pointer"><%=t 'views.registrations.referral_code_link' %></label></p>
+            </div>
+            <%= form_with url: lookup_referral_codes_path, html: { class: 'collapse-content mt-3', 'data-target': 'referral-code.form', 'data-action': 'referral-code#submit' } do |f| %>
+              <div class="flex">
+                <%= f.text_field :code, size: 'auto', class: 'input w-full flex-grow mr-2', placeholder: t('views.registrations.referral_code') %>
+                <%= f.submit 'OK', class: 'button', data: { disable_with: false } %>
+              </div>
+              <p class="text-orange-shade-1 mt-1" data-target="referral-code.errorMessage"></p>
+            <% end %>
+          </div>
 
-          <p class="text-center text-sm" data-target="membership-choice.subscriptionInfo" data-active-class="text-center text-sm block" data-inactive-class="text-center text-sm hidden">
-            <a href="#where-does-the-money-go" class="link inline" data-controller="scroll-to" data-action="scroll-to#scroll"><%= t 'views.registrations.where_does_the_money_go.heading' %></a>
-          </p>
+          <div class="py-6 space-y-1">
+            <p class="heading-lg text-center">
+              <span data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden"><%=t 'views.registrations.first_month_free' %></span>
+              <span data-target="referral-code.noCodeActiveInfo" data-inactive-class="hidden"><span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %></span>
+            </p>
+            <p data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden" data-active-class="font-bold text-center">
+              <%=t 'views.registrations.then' %> <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
+            </p>
+
+            <p class="text-center text-sm">
+              <a href="#where-does-the-money-go" class="link inline" data-controller="scroll-to" data-action="scroll-to#scroll"><%= t 'views.registrations.where_does_the_money_go.heading' %></a>
+            </p>
+          </div>
+        </div>
+        <div class="hidden" data-target="membership-choice.noSubscriptionInfo" data-inactive-class="hidden">
+          <div class="py-6 space-y-1">
+            <p class="heading-lg text-center">
+              <span class="hidden" data-target="membership-choice.noSubscriptionInfo" data-active-class="inline" data-inactive-class="hidden"><%= t 'views.registrations.price_free' %></span>
+            </p>
+          </div>
         </div>
 
         <label for="step-one-done" id="continue-to-payment" class="button button-cta w-full">
@@ -72,6 +99,7 @@
       <%= form_with url: registration_path(resource_name, format: :json), html: { 'data-target': 'registration-form.form' } do |f| %>
         <%= f.hidden_field(:lifestyle_footprint, :value => @footprint&.key) %>
         <%= f.hidden_field :people, value: (params[:people].presence || 1), 'data-target': 'registration-price.peopleField' %>
+        <%= f.hidden_field :referral_code, 'data-target': 'referral-code.activeCodeField' %>
         <%= f.hidden_field :membership, value: '', 'data-target': 'membership-choice.membershipField' %>
         <%= fields_for @user do |user_form| %>
           <%= user_form.hidden_field :region %>
@@ -104,18 +132,28 @@
         <% end %>
       <% end %>
 
-      <div class="py-6 space-y-1">
-        <p class="heading-lg text-center">
-          <span data-target="membership-choice.subscriptionInfo" data-active-class="inline" data-inactive-class="hidden">
-            <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
-          </span>
-          <span class="hidden" data-target="membership-choice.noSubscriptionInfo" data-active-class="inline" data-inactive-class="hidden"><%= t 'views.registrations.price_free' %></span>
-        </p>
+      <div data-target="membership-choice.subscriptionInfo" data-inactive-class="hidden">
+        <div class="py-6 space-y-1">
+          <p class="heading-lg text-center">
+            <span data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden"><%=t 'views.registrations.first_month_free' %></span>
+            <span data-target="referral-code.noCodeActiveInfo" data-inactive-class="hidden"><span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %></span>
+          </p>
+          <p data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden" data-active-class="font-bold text-center">
+            <%=t 'views.registrations.then' %> <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
+          </p>
 
-        <p class="text-center text-sm" data-target="membership-choice.subscriptionInfo" data-active-class="text-center text-sm block" data-inactive-class="text-center text-sm hidden">
-          <a href="#where-does-the-money-go" class="link inline" data-controller="scroll-to" data-action="scroll-to#scroll"><%= t 'views.registrations.where_does_the_money_go.heading' %></a>
-        </p>
+          <p class="text-center text-sm">
+            <a href="#where-does-the-money-go" class="link inline" data-controller="scroll-to" data-action="scroll-to#scroll"><%= t 'views.registrations.where_does_the_money_go.heading' %></a>
+          </p>
+        </div>
       </div>
+        <div class="hidden" data-target="membership-choice.noSubscriptionInfo" data-inactive-class="hidden">
+          <div class="py-6 space-y-1">
+            <p class="heading-lg text-center">
+              <span class="hidden" data-target="membership-choice.noSubscriptionInfo" data-active-class="inline" data-inactive-class="hidden"><%= t 'views.registrations.price_free' %></span>
+            </p>
+          </div>
+        </div>
 
       <button class="button button-cta w-full"
         data-target="registration-form.submitButton membership-choice.subscriptionInfo"

--- a/app/views/devise/registrations/new_campaign.html.erb
+++ b/app/views/devise/registrations/new_campaign.html.erb
@@ -77,7 +77,7 @@
     </div>
   </section>
 
-  <section class="section-padding space-y-6" data-controller="registration-price">
+  <section class="section-padding space-y-6" data-controller="registration-price referral-code">
     <h2 class="heading-lg text-center"><%= t 'views.registrations.know_your_footprint.sign_up.heading' %></h2>
     <p class="max-w-2xl mx-auto"><%= t 'views.registrations.know_your_footprint.sign_up.text' %></p>
     <div class="flex flex-col t:flex-row t:justify-center items-center space-y-6 t:space-y-0 t:space-x-6" data-controller="membership-choice-campaign">
@@ -144,9 +144,36 @@
 
           <div class="h-px w-full bg-gray-tint-2"></div>
 
-          <p class="heading-lg text-center py-6">
-            <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
-          </p>
+          <div class="mt-3 collapse">
+            <input type="checkbox" id="enter_referral_code" data-target="referral-code.formPresentedCheckbox" class="hidden">
+            <div data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden">
+              <p class="text-center text-sm"><%=t 'views.registrations.referral_code' %>: <strong data-target="referral-code.activeCode" class="mr-1"></strong> <label for="enter_referral_code" class="link cursor-pointer"><%=t 'views.registrations.referral_code_change' %></label></p>
+            </div>
+            <div data-target="referral-code.noCodeActiveInfo" data-inactive-class="hidden">
+              <p class="text-center text-sm"><label for="enter_referral_code" class="link cursor-pointer"><%=t 'views.registrations.referral_code_link' %></label></p>
+            </div>
+            <%= form_with url: lookup_referral_codes_path, html: { class: 'collapse-content mt-3', 'data-target': 'referral-code.form', 'data-action': 'referral-code#submit' } do |f| %>
+              <div class="flex">
+                <%= f.text_field :code, size: 'auto', class: 'input w-full flex-grow mr-2', placeholder: t('views.registrations.referral_code') %>
+                <%= f.submit 'OK', class: 'button', data: { disable_with: false } %>
+              </div>
+              <p class="text-orange-shade-1 mt-1" data-target="referral-code.errorMessage"></p>
+            <% end %>
+          </div>
+
+          <div class="py-6 space-y-1">
+            <p class="heading-lg text-center">
+              <span data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden"><%=t 'views.registrations.first_month_free' %></span>
+              <span data-target="referral-code.noCodeActiveInfo" data-inactive-class="hidden"><span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %></span>
+            </p>
+            <p data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden" data-active-class="font-bold text-center">
+              <%=t 'views.registrations.then' %> <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
+            </p>
+
+            <p class="text-center text-sm">
+              <a href="#where-does-the-money-go" class="link inline" data-controller="scroll-to" data-action="scroll-to#scroll"><%= t 'views.registrations.where_does_the_money_go.heading' %></a>
+            </p>
+          </div>
 
           <button type="button" class="button button-cta w-full" data-action="membership-choice-campaign#showPaying"><%= t 'views.registrations.continue_to_payment' %></button>
         </div>
@@ -214,6 +241,7 @@
         <%= form_with url: registration_path(resource_name, format: :json), class: 'space-y-3', html: { 'data-target': 'registration-form.form' } do |f| %>
           <%= f.hidden_field(:lifestyle_footprint, :value => @footprint&.key) %>
           <%= f.hidden_field :people, value: (params[:people].presence || 1), 'data-target': 'registration-price.peopleField' %>
+          <%= f.hidden_field :referral_code, 'data-target': 'referral-code.activeCodeField' %>
           <%= f.hidden_field :membership, value: 'multi' %>
           <%= fields_for @user do |user_form| %>
             <%= user_form.hidden_field :region %>
@@ -250,7 +278,11 @@
 
           <div class="py-6 space-y-1">
             <p class="heading-lg text-center">
-              <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
+              <span data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden"><%=t 'views.registrations.first_month_free' %></span>
+              <span data-target="referral-code.noCodeActiveInfo" data-inactive-class="hidden"><span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %></span>
+            </p>
+            <p data-target="referral-code.codeActiveInfo" class="hidden" data-inactive-class="hidden" data-active-class="font-bold text-center">
+              <%=t 'views.registrations.then' %> <span data-target="registration-price.price"><%= @plan_price.to_s(precision: :auto) %></span>/<%= t 'months.one' %>
             </p>
 
             <p class="text-center text-sm" data-target="membership-choice.subscriptionInfo" data-active-class="text-center text-sm block" data-inactive-class="text-center text-sm hidden">

--- a/config/locales/views/registrations.en.yml
+++ b/config/locales/views/registrations.en.yml
@@ -19,6 +19,11 @@ en:
       create_account: Create account
       your_subscription: Your subscription
       number_of_people: Number of people
+      referral_code: Referral code
+      referral_code_change: Change
+      referral_code_link: Have a referral code?
+      first_month_free: First month free
+      then: Then
       membership:
         free: <span>Free account</span>. Track your carbon footprint over time.
         single: <span>Offset</span> your carbon footprint through climate projects.

--- a/config/locales/views/registrations.sv.yml
+++ b/config/locales/views/registrations.sv.yml
@@ -17,6 +17,11 @@ sv:
       create_account: Skapa konto
       your_subscription: Din prenumeration
       number_of_people: Antal personer
+      referral_code: Kod
+      referral_code_change: Byt
+      referral_code_link: Har du en kod att skriva in?
+      first_month_free: Första månaden gratis
+      then: Därefter
       membership:
         free: <span>Gratis konto</span>. Spara och följ ditt klimatavtryck över tid.
         single: <span>Kompensera</span> ditt avtryck genom klimatprojekt.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,11 @@ Rails.application.routes.draw do
     resource :travel_calculator, controller: 'travel_calculator', path: 'travel-calculator', only: [:show]
 
     resources :lifestyle_footprints, path: 'calculator', only: [:new, :create], path_names: { new: '' }
+    resources :referral_codes, path: 'referral-codes', only: [] do
+      collection do
+        post :lookup
+      end
+    end
 
     resources :projects, path: 'climate-projects', only: [:index]
 

--- a/db/migrate/20201031191901_alter_referral_codes_index.rb
+++ b/db/migrate/20201031191901_alter_referral_codes_index.rb
@@ -1,0 +1,6 @@
+class AlterReferralCodesIndex < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :referral_codes, :code
+    add_index :referral_codes, 'lower(code)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_28_072101) do
+ActiveRecord::Schema.define(version: 2020_10_31_191901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,7 +229,7 @@ ActiveRecord::Schema.define(version: 2020_10_28_072101) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "code"
     t.text "destination_path"
-    t.index ["code"], name: "index_referral_codes_on_code"
+    t.index "lower(code)", name: "index_referral_codes_on_lower_code"
   end
 
   create_table "stripe_payouts", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,3 +43,7 @@ User.create!(
 )
 
 ActiveRecord::Base.connection.set_pk_sequence!(:users, 2)
+
+ReferralCode.create!(
+  code: 'gofriends'
+)

--- a/spec/factories/referral_code.rb
+++ b/spec/factories/referral_code.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :referral_code
+end

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -74,6 +74,52 @@ RSpec.feature 'Registrations', type: :feature, js: true do
     expect(User.last.stripe_customer.subscriptions.first.status).to eq('active')
   end
 
+  scenario 'Register with referral code' do
+    # Homepage
+    visit '/?enable_experiments=new_signup'
+
+    select('Sweden', from: 'country')
+    click_button 'Get started'
+
+    # Calculator
+    find('label', text: 'Apartment').click
+    find('label', text: 'Electricity').click
+    find('label', text: 'Yes').click
+    find('label', text: 'Vegetarian').click
+    find('label', text: 'I don\'t have a car').click
+    click_button 'Next'
+
+    # Sign up page
+    find('label', text: 'Have a referral code?').click
+    fill_in 'Referral code', with: 'gofriends'
+    click_button 'OK'
+    expect(page).to have_text 'First month free'
+
+    find('#continue-to-payment').click
+    fill_in 'Email', with: 'test@example.com'
+    fill_in 'Password', with: 'password'
+    within_frame(0) do
+      send_keys_to_card_field '4000002500003155'
+      find('input[name=exp-date]').send_keys '522'
+      find('input[name=cvc]').send_keys '123'
+    end
+    check 'I accept our Privacy policy'
+    click_button 'Start subscription'
+
+    # 3D Secure authorization pop up
+    authorize_3d_secure
+
+    # Wait for success page to render
+    find('.dashboard-show', wait: 20)
+
+    expect(page).to have_text 'Welcome to a climate neutral life'
+    expect(Stripe::Invoice.retrieve(User.last.stripe_customer.subscriptions.first.latest_invoice).total).to eq(0)
+    expect(User.last.stripe_customer.subscriptions.first.status).to eq('trialing')
+    subscription = nil
+    expect { subscription = trigger_next_subscription_charge }.not_to raise_error
+    expect(subscription.status).to eq('active')
+  end
+
   scenario 'Register without subscription' do
     visit '/'
 
@@ -205,5 +251,16 @@ RSpec.feature 'Registrations', type: :feature, js: true do
 
     expect(page).to have_text 'Welcome to GoClimate!'
     expect(User.last.stripe_customer.subscriptions.first).to eq(nil)
+  end
+
+  def trigger_next_subscription_charge
+    Stripe::Subscription.update(
+      User.last.stripe_customer.subscriptions.first.id,
+      billing_cycle_anchor: 'now',
+      # This wouldn't happen in production of course, but we need to end the trial to trigger the next charge
+      trial_end: 'now',
+      proration_behavior: 'none',
+      off_session: true
+    )
   end
 end

--- a/spec/fixtures/files/stripe/subscription.json
+++ b/spec/fixtures/files/stripe/subscription.json
@@ -20,7 +20,7 @@
   "metadata": {},
   "plan": {"id":"climate_offset_3_6_usd_monthly","object":"plan","active":true,"aggregate_usage":null,"amount":360,"billing_scheme":"per_unit","created":1539029173,"currency":"usd","interval":"month","interval_count":1,"livemode":false,"metadata":{},"nickname":null,"product":"prod_Dka9IawzVZYo19","tiers":null,"tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},
   "quantity": 1,
-  "start": 1547542731,
+  "start_date": 1547542731,
   "status": "active",
   "tax_percent": null,
   "trial_end": null,


### PR DESCRIPTION
Sign up page markup & JS is getting complicated, but this should work well for now.

# Todo

- [x] Make sure 3D Secure cards work (they will probably not have a payment intent for the first month and will instead have to use `SetupIntent`s to verify the card for future payments)
- [x] Make using referral codes case-insensitive
- [x] Localization
- [x] Rebase to master after #408 is merged and add referral code UI on the campaign page