### PR TITLE
Show total users as member count

### DIFF
--- a/app/controllers/about/transparency_controller.rb
+++ b/app/controllers/about/transparency_controller.rb
@@ -3,7 +3,7 @@
 module About
   class TransparencyController < ApplicationController
     def show
-      @unique_climate_neutral_users = User.with_active_subscription.count
+      @total_users = User.count
       @total_carbon_offset = OffsettingStatistics.new.total_sold.tonnes.round
       @number_of_countries = User.distinct.pluck(:country).compact.count
       @number_of_businesses_helped = Invoice.distinct.pluck(:receiver).count +

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -10,7 +10,7 @@ class DashboardController < ApplicationController
     @total_carbon_offset = OffsettingStatistics.new.total_sold.tonnes.round
     @my_carbon_offset = current_user.total_subscription_offsetting.tonnes
     @my_neutral_months = current_user.number_of_neutral_months
-    @unique_climate_neutral_users = User.with_active_subscription.count
+    @total_users = User.count
 
     @footprint = current_user.current_lifestyle_footprint
     # Some old users don't have LifestyleFootprints

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@
 
 class HomeController < ApplicationController
   def show
-    @unique_climate_neutral_users = User.with_active_subscription.count
+    @total_users = User.count
     @total_carbon_offset = OffsettingStatistics.new.total_sold.tonnes.round
     @latest_project = Project.order(date_bought: :desc).first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,10 +10,6 @@ class User < ApplicationRecord
   has_many :subscription_months
   belongs_to :referred_from, class_name: 'ReferralCode', optional: true
 
-  scope :with_active_subscription, lambda {
-    where(subscription_end_at: nil).or(where('subscription_end_at >= ?', Time.now))
-  }
-
   validates :user_name, format: { without: /.+@.+\..+/ }, allow_blank: true
 
   attribute :region, :region

--- a/app/views/about/transparency/show.html.erb
+++ b/app/views/about/transparency/show.html.erb
@@ -36,7 +36,7 @@
     <dd class="t:ml-1/2 t:w-1/2 mt-1 text-center text-lg"><strong>473</strong> kg CO2e</dd>
 
     <dt class="t:float-left t:clear-left t:w-1/2 mt-12 text-center font-bold"><%=t 'number_of_climate_neutral_users' %></dt>
-    <dd class="t:float-left t:clear-left t:w-1/2 mt-1 text-center text-lg"><strong><%= number_with_delimiter(@unique_climate_neutral_users) %></strong></dd>
+    <dd class="t:float-left t:clear-left t:w-1/2 mt-1 text-center text-lg"><strong><%= number_with_delimiter(@total_users) %></strong></dd>
 
     <dt class="t:ml-1/2 t:w-1/2 mt-12 text-center font-bold"><%=t 'users_from' %></dt>
     <dd class="t:ml-1/2 t:w-1/2 mt-1 text-center text-lg"><strong><%= @number_of_countries %></strong> <%=t 'different_countries' %></dd>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -36,7 +36,7 @@
         </div>
 
         <div class="text-center mt-12">
-          <%= raw(t('dashboard.together', number_of_members: @unique_climate_neutral_users, number_of_tonnes: number_with_delimiter(@total_carbon_offset)).gsub('<span>', '<span class="font-bold">')) %>
+          <%= raw(t('dashboard.together', number_of_members: @total_users, number_of_tonnes: number_with_delimiter(@total_carbon_offset)).gsub('<span>', '<span class="font-bold">')) %>
         </div>
       </div>
     </section>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -49,8 +49,8 @@
           <p class="font-bold text-5xl text-green-accent text-center">
             <span id="total-users"
               data-controller="counting-number"
-              data-target-number="<%= @unique_climate_neutral_users %>">
-              <%= number_with_delimiter(@unique_climate_neutral_users) %>
+              data-target-number="<%= @total_users %>">
+              <%= number_with_delimiter(@total_users) %>
             </span>
           </p>
           <p><%=t 'welcome.users_suffix' %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -23,7 +23,6 @@ de:
   full_time: Vollzeit
   Main_KPI: Die wichtigsten KPI
   climate_footprint_2019: Klimabilanz 2019
-  number_of_climate_neutral_users: Anzahl klimaneutraler Nutzer
   users_from: Nutzer von
   different_countries: verschiedene Länder
   number_of_companies_we_have_helped: Anzahl der Unternehmen, denen wir geholfen haben
@@ -105,7 +104,7 @@ de:
     heading: Hallo Klima-Freund!
     your_months: Sie sind klimaneutral seit
     your_offsets: Ihr CO2-Ausgleich beläuft sich auf
-    together: Zusammen mit allen <span>%{number_of_members} Mitgliedern</span>haben wir verhindert, dass <span>%{number_of_tonnes} Tonnen</span> CO2 in die Atmosphäre gelangen!
+    together: Zusammen mit allen <span>%{number_of_members} Mitgliedern</span> haben wir verhindert, dass <span>%{number_of_tonnes} Tonnen</span> CO2 in die Atmosphäre gelangen!
   good_job: Gut gemacht!
   our_projects: Unsere Klimainvestitionen
   project_name: Projekt
@@ -226,7 +225,6 @@ de:
     gift_cards: Gutscheine
   welcome:
     users_prefix: Aktuell sind wir
-    users_suffix: klimaneutrale Nutzer
     tonnes_prefix: Gemeinsam haben wir
     tonnes_suffix: Tonnen CO2 in der Atmosphäre reduziert
     how_it_works:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
   full_time: full time
   Main_KPI: Main KPI
   climate_footprint_2019: Climate footprint 2019
-  number_of_climate_neutral_users: Number of climate neutral users
+  number_of_climate_neutral_users: Number of community members
   users_from: Users from
   different_countries: different countries
   number_of_companies_we_have_helped: Number of companies we have helped

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -23,7 +23,7 @@ sv:
   full_time: heltidsanställda
   Main_KPI: Fokus-KPI
   climate_footprint_2019: Klimatavtryck 2019
-  number_of_climate_neutral_users: Antal klimatneutrala användare
+  number_of_climate_neutral_users: Antal medlemmar
   users_from: Användare från
   different_countries: olika länder
   number_of_companies_we_have_helped: Antal företag som vi har hjälpt

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -92,38 +92,6 @@ RSpec.describe User do
     end
   end
 
-  describe '.with_active_subscription' do
-    context 'with user with active subscription' do
-      before do
-        create(:user)
-      end
-
-      it 'includes it' do
-        expect(described_class.with_active_subscription.count).to eq(1)
-      end
-    end
-
-    context 'with user with subscription that will end but has not yet' do
-      before do
-        create(:user_with_subscription_ending_in_future)
-      end
-
-      it 'includes it' do
-        expect(described_class.with_active_subscription.count).to eq(1)
-      end
-    end
-
-    context 'with users without active subscription' do
-      before do
-        create(:user_with_ended_subscription)
-      end
-
-      it 'does not include it' do
-        expect(described_class.with_active_subscription.count).to eq(0)
-      end
-    end
-  end
-
   describe '#update_from_stripe_subscription' do
     let(:current_subscription) do
       Stripe::Subscription.construct_from(stripe_json_fixture('subscription.json'))


### PR DESCRIPTION
Since we now allow signing up for an account without starting a subscription and we have to goal of helping those users make an impact in other ways than offsetting too, we want to include those in the number of community members too.