### PR TITLE
Force adding a new card when absent in subscription settings

### DIFF
--- a/app/views/users/subscriptions/show.html.erb
+++ b/app/views/users/subscriptions/show.html.erb
@@ -23,8 +23,6 @@
 
           <p id="error-content"></p>
 
-          <%= hidden_field(:setup_intent, :client_secret) %>
-
           <div>
             <label for="plan" class="block font-bold"><%= t 'climate_plan' %></label>
             <div class="select-wrapper w-full">
@@ -42,46 +40,42 @@
             </div>
           </div>
 
-          <div id="current-card-group">
-            <label for="current-card" class="font-bold">
-              <%=t 'credit_or_debit_card' %>
-            </label>
+          <% if @customer_payment_method.present? %>
+            <div>
+              <label for="current-card" class="font-bold"><%=t 'credit_or_debit_card' %></label>
 
-            <div id="current-card" class="m-lg:flex m-lg:items-center m-lg:justify-between">
-              <% if @customer_payment_method.nil? %>
-                <%= t('no_card_registered') %>
-              <% else %>
-                <div>
-                  <span>
-                    <% if card_brand(@customer_payment_method) == 'visa' %>
-                      <span class="card-visa"></span>
-                    <% elsif card_brand(@customer_payment_method) == 'mastercard' %>
-                      <span class="card-mastercard"></span>
-                    <% end %>
-                    <%= masked_card_number(@customer_payment_method) %>
-                  </span>
-                  <span class="card-expiration"><%= card_expiration(@customer_payment_method) %></span>
+              <div id="current-card" class="m-lg:flex m-lg:items-center m-lg:justify-between">
+                <span>
+                  <% if card_brand(@customer_payment_method) == 'visa' %>
+                    <span class="card-visa"></span>
+                  <% elsif card_brand(@customer_payment_method) == 'mastercard' %>
+                    <span class="card-mastercard"></span>
+                  <% end %>
+                  <%= masked_card_number(@customer_payment_method) %>
+                </span>
+                <span class="card-expiration"><%= card_expiration(@customer_payment_method) %></span>
+
+                <div class="mt-1 capitalize">
+                  <button type="button" id="add-new-card" class="button" data-action="payment-settings#showStripeCardField"><%= @customer_payment_method.nil? ? t('add_new_card') : t('edit_card') %></button>
                 </div>
-              <% end %>
-
-              <div class="mt-1 capitalize">
-                <button type="button" id="add-new-card" class="button" data-action="payment-settings#showStripeCardField"><%= @customer_payment_method.nil? ? t('add_new_card') : t('edit_card') %></button>
               </div>
             </div>
-          </div>
+          <% end %>
 
-          <div id="new-card-div" class="hidden" data-controller="stripe-card-element" data-target="payment-settings.stripeCardElement">
-            <label for="card-element" class="font-bold"><%=t 'add_new_card' %></label>
+          <div id="new-card-div" <% if @customer_payment_method.present? %> class="hidden"<% end %> data-controller="stripe-card-element" data-target="payment-settings.stripeCardElement">
+            <label for="card-element" class="font-bold">
+              <%=t @customer_payment_method.present? ? 'add_new_card' : 'credit_or_debit_card' %>
+            </label>
             <div id="card-element" class="input my-1" data-target="stripe-card-element.container"></div>
             <div class="text-orange-shade-1" data-target="stripe-card-element.errors"></div>
             <%= hidden_field_tag :payment_method_id, nil, 'data-target': 'stripe-card-element.paymentMethodField' %>
-          </div>
 
-          <div>
-            <i class="fa fa-lock" aria-hidden="true"></i> <span class="ml-1">Secured by Stripe</span>
-          </div>
+            <div>
+              <i class="fa fa-lock" aria-hidden="true"></i> <span class="ml-1">Secured by Stripe</span>
+            </div>
 
-          <div id="card-errors" class="text-orange-shade-1" data-target="payment-settings.errorMessage"></div>
+            <div id="card-errors" class="text-orange-shade-1" data-target="payment-settings.errorMessage"></div>
+          </div>
 
           <div class="actions">
             <button id="register-button" type="submit" class="button button-cta w-full" data-target="payment-settings.submitButton" data-action="payment-settings#submit">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -85,7 +85,6 @@ de:
   add_new_card: Neue Karte hinzufügen
   edit_card: Kartendetails bearbeiten
   your_payment_details_have_been_updated: Ihre Einstellungen wurden aktualisiert
-  no_card_registered: Keine Karte registriert
   climate_plan: Klimaplan
   log_in_to_see_how_we_are_doing: Der Klimawandel ist die größte Herausforderung unserer Zeit. Loggen Sie sich ein, um zu erfahren, wie weit wir im Kampf gegen den Klimawandel schon gekommen sind.
   you_have_lived_climate_neutral_for:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,6 @@ en:
   add_new_card: Add new card
   edit_card: Edit card
   your_payment_details_have_been_updated: Your settings has been updated
-  no_card_registered: No Card Registered
   climate_plan: Climate Plan
   log_in_to_see_how_we_are_doing: Climate change is the biggest challenge of our time. Log in to see how we are doing in our fight to stop it.
   you_have_lived_climate_neutral_for:

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -88,7 +88,6 @@ eo:
   add_new_card: crwdns11888:0crwdne11888:0
   edit_card: crwdns14866:0crwdne14866:0
   your_payment_details_have_been_updated: crwdns11892:0crwdne11892:0
-  no_card_registered: crwdns11894:0crwdne11894:0
   climate_plan: crwdns11896:0crwdne11896:0
   log_in_to_see_how_we_are_doing: crwdns11900:0crwdne11900:0
   you_have_lived_climate_neutral_for:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -88,7 +88,6 @@ sv:
   add_new_card: Nytt kort
   edit_card: Ändra kort
   your_payment_details_have_been_updated: Dina inställningar har uppdaterats
-  no_card_registered: Inget kort registrerat
   climate_plan: Kompensation
   log_in_to_see_how_we_are_doing: Logga in för att se hur det går i vår kamp med att försöka ställa klimatet till rätta igen.
   you_have_lived_climate_neutral_for:

--- a/spec/features/subscription_settings_spec.rb
+++ b/spec/features/subscription_settings_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'Subscription settings', js: true do
   scenario 'Enable subscription' do
     visit '/users/subscription'
     select '€2', from: 'Climate Plan'
-    click_button 'Add new card'
     within_frame(0) do
       send_keys_to_card_field '4242424242424242'
       find('input[name=exp-date]').send_keys '522'
@@ -32,7 +31,6 @@ RSpec.feature 'Subscription settings', js: true do
   scenario 'Enable subscription with 3D Secure card' do
     visit '/users/subscription'
     select '€2', from: 'Climate Plan'
-    click_button 'Add new card'
     within_frame(0) do
       send_keys_to_card_field '4000002500003155'
       find('input[name=exp-date]').send_keys '522'


### PR DESCRIPTION
Fixes a crash that one runs into when posting subscription settings in cases where no card is tied to the account and not having filled in new card details.

Looks like this when no card is tied to the account:
<img width="885" alt="Screen Shot 2020-11-18 at 13 04 46" src="https://user-images.githubusercontent.com/90949/99530127-2e686880-29a1-11eb-943b-17ba8880dee4.png">

And like before when a card is tied to the account:
<img width="889" alt="Screen Shot 2020-11-18 at 13 20 04" src="https://user-images.githubusercontent.com/90949/99530141-36280d00-29a1-11eb-9d28-f77efe494183.png">
