### PR TITLE
Display shopping separately from public emissions in footprint charts

### DIFF
--- a/app/views/shared/_chart_categories.html.erb
+++ b/app/views/shared/_chart_categories.html.erb
@@ -1,6 +1,6 @@
 <div class="relative pb-1">
   <div class="space-y-6">
-    <% max_value_categories = [@footprint.housing.tonnes.round(1), @footprint.food.tonnes.round(1), @footprint.car.tonnes.round(1), @footprint.flights.tonnes.round(1), (@footprint.public.tonnes.round(1) + @footprint.consumption.tonnes.round(1))].max %>
+    <% max_value_categories = [@footprint.housing.tonnes.round(1), @footprint.food.tonnes.round(1), @footprint.car.tonnes.round(1), @footprint.flights.tonnes.round(1), @footprint.public.tonnes.round(1), @footprint.consumption.tonnes.round(1)].max %>
     <% [
         {
           amount: @footprint.housing,
@@ -28,11 +28,17 @@
           'bg-color': 'bg-blue-accent'
         },
         {
+          amount: @footprint.consumption,
+          icon: 'fa-shopping-bag',
+          title: t('dashboard.footprint.category.shopping'),
+          'bg-color': 'bg-pink-accent'
+        },
+        {
           key: 'public',
-          amount: @footprint.public + @footprint.consumption,
+          amount: @footprint.public,
           icon: 'fa-university',
           title: t('dashboard.footprint.category.public'),
-          'bg-color': 'bg-pink-accent'
+          'bg-color': 'bg-gray-accent'
         },
       ].each do |footprint| %>
       <div class="space-y-2">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -112,7 +112,8 @@ de:
         food: Ernährung
         car: Auto
         flights: Flüge
-        public: Öffentliche Emissionen und Einkäufe
+        shopping: Einkäufe
+        public: Öffentliche Emissionen
   good_job: Gut gemacht!
   our_projects: Unsere Klimainvestitionen
   project_name: Projekt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,7 +121,8 @@ en:
         food: Food
         car: Car
         flights: Flights
-        public: Public emissions and shopping
+        shopping: Shopping
+        public: Public emissions
   good_job: Good job!
   our_projects: Our Climate Projects
   project_name: Project name

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -121,7 +121,8 @@ sv:
         food: Mat
         car: Bil
         flights: Flyg
-        public: Samhälle och shopping
+        shopping: Shopping
+        public: Samhälle
   good_job: Bra jobbat!
   our_projects: Våra klimatprojekt
   project_name: Namn på projekt


### PR DESCRIPTION
See discussion on Slack.

<img width="1241" alt="Screen Shot 2020-11-26 at 10 23 50" src="https://user-images.githubusercontent.com/90949/100332897-40b25a00-2fd2-11eb-8bc8-5d80f2f16f7f.png">
<img width="651" alt="Screen Shot 2020-11-26 at 10 16 00" src="https://user-images.githubusercontent.com/90949/100332901-4314b400-2fd2-11eb-81cd-ce7078ebb99f.png">
